### PR TITLE
Use common cf variables in setup.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,14 +43,6 @@ setup_hbw() {
     # (HBW = hh2bbww, CF = columnflow)
     #
 
-    # lang defaults
-    export LANGUAGE="${LANGUAGE:-en_US.UTF-8}"
-    export LANG="${LANG:-en_US.UTF-8}"
-    export LC_ALL="${LC_ALL:-en_US.UTF-8}"
-
-    # proxy
-    export X509_USER_PROXY="${X509_USER_PROXY:-/tmp/x509up_u$( id -u )}"
-
     # start exporting variables
     export HBW_BASE="${this_dir}"
     export CF_BASE="${this_dir}/modules/columnflow"
@@ -95,19 +87,12 @@ setup_hbw() {
     export CF_CMSSW_BASE="${CF_CMSSW_BASE:-${CF_SOFTWARE_BASE}/cmssw}"
     export CF_CI_JOB="$( [ "${GITHUB_ACTIONS}" = "true" ] && echo 1 || echo 0 )"
 
-    # overwrite some variables in remote and CI jobs
-    if [ "${CF_REMOTE_JOB}" = "1" ]; then
-        export CF_WLCG_USE_CACHE="true"
-        export CF_WLCG_CACHE_CLEANUP="true"
-        export CF_WORKER_KEEP_ALIVE="false"
-    elif [ "${CF_CI_JOB}" = "1" ]; then
-        export CF_WORKER_KEEP_ALIVE="false"
-    fi
 
-    # some variable defaults
-    export CF_WORKER_KEEP_ALIVE="${CF_WORKER_KEEP_ALIVE:-false}"
-    export CF_SCHEDULER_HOST="${CF_SCHEDULER_HOST:-127.0.0.1}"
-    export CF_SCHEDULER_PORT="${CF_SCHEDULER_PORT:-8082}"
+    #
+    # common variables
+    #
+
+    cf_setup_common_variables || return "$?"
 
 
     #


### PR DESCRIPTION
This change avoids the need to setup variables in this analysis' `setup.sh` that columnflow requires and with https://github.com/uhh-cms/columnflow/pull/132 included, can initialize on its own.

Please merge only after the above PR is included and your columnflow submodule is updated.