### PR TITLE
Selection updates

### DIFF
--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -225,6 +225,8 @@ def add_config(
     # category groups for conveniently looping over certain categories
     # (used during plotting)
     cfg.x.category_groups = {
+        "much": ["1mu", "1mu__resolved", "1mu__boosted"],
+        "ech": ["1e", "1e__resolved", "1e__boosted"],
         "default": ["incl", "1e", "1mu"],
         "test": ["incl", "1e"],
     }

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -635,15 +635,11 @@ def add_config(
             # NOTE: if we run into storage troubles, skip Bjet and Lightjet
             for field in ["pt", "eta", "phi", "mass", "btagDeepFlavB", "hadronFlavour"]
         ) | set(  # H->bb FatJet
-            f"HbbJet.{field}"
+            f"{jet_type}.{field}"
+            for jet_type in ["FatJet", "HbbJet"]
             for field in [
                 "pt", "eta", "phi", "mass", "msoftdrop", "tau1", "tau2", "tau3",
                 "btagHbb", "deepTagMD_HbbvsQCD", "particleNet_HbbvsQCD",
-            ]
-        ) | set(  # FatJet
-            f"FatJet.{field}"
-            for field in [
-                "pt",
             ]
         ) | set(  # Leptons
             f"{lep}.{field}"

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -634,11 +634,16 @@ def add_config(
             for jet_obj in ["Jet", "Bjet", "Lightjet", "VBFJet"]
             # NOTE: if we run into storage troubles, skip Bjet and Lightjet
             for field in ["pt", "eta", "phi", "mass", "btagDeepFlavB", "hadronFlavour"]
-        ) | set(  # FatJet
-            f"FatJet.{field}"
+        ) | set(  # H->bb FatJet
+            f"HbbJet.{field}"
             for field in [
                 "pt", "eta", "phi", "mass", "msoftdrop", "tau1", "tau2", "tau3",
                 "btagHbb", "deepTagMD_HbbvsQCD", "particleNet_HbbvsQCD",
+            ]
+        ) | set(  # FatJet
+            f"FatJet.{field}"
+            for field in [
+                "pt",
             ]
         ) | set(  # Leptons
             f"{lep}.{field}"

--- a/hbw/config/variables.py
+++ b/hbw/config/variables.py
@@ -131,13 +131,29 @@ def add_variables(config: od.Config) -> None:
     # Weights
     #
 
+    # TODO: implement tags in columnflow; meanwhile leave these variables commented out (as they only work for mc)
     """
-    # NOTE: mc_weight needed for cutflow plots, but can't be used with data :(
     config.add_variable(
         name="mc_weight",
         expression="mc_weight",
-        binning=(200, -10, 10),
+        binning=list(np.logspace(1.2, 5, 200)),
+        log_x=True,
         x_title="MC weight",
+        tags={"mc_only"},
+    )
+    config.add_variable(
+        name="normalization_weight",
+        binning=list(np.logspace(0, 6, 100)),
+        log_x=True,
+        x_title="normalization weight",
+        tags={"mc_only"},
+    )
+    config.add_variable(
+        name="event_weight",
+        binning=list(np.logspace(0, 6, 100)),
+        log_x=True,
+        x_title="event weight",
+        tags={"mc_only"},
     )
 
     for weight in ["pu", "pdf", "mur", "muf", "murf_envelope"]:
@@ -147,16 +163,17 @@ def add_variables(config: od.Config) -> None:
             expression=f"{weight}_weight",
             binning=(40, -2, 2),
             x_title=f"{weight} weight",
+            tags={"mc_only"},
         )
         config.add_variable(
-            name="pu_weight_log",
+            name=f"{weight}_weight_log",
             expression=f"{weight}_weight",
-            binning=list(np.logspace(-2, 2, 50)),
+            binning=list(np.logspace(-2, 2, 100)),
             log_x=True,
-            x_title="PU weight",
+            x_title=f"{weight} weight",
+            tags={"mc_only"},
         )
     """
-
     config.add_variable(
         name="npvs",
         expression="PV.npvs",

--- a/hbw/tasks/wrapper.py
+++ b/hbw/tasks/wrapper.py
@@ -1,0 +1,82 @@
+# coding: utf-8
+
+"""
+Convenience wrapper tasks to simplify producing results and fetching & deleting their outputs
+e.g. default sets of plots or datacards
+"""
+
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin,  # SelectorStepsMixin, ProducersMixin, MLModelsMixin,
+)
+from columnflow.tasks.plotting import PlotVariables1D
+# from columnflow.tasks.framework.remote import RemoteWorkflow
+
+from columnflow.util import dev_sandbox
+
+
+class DefaultPlots(
+    # MLModelsMixin,
+    # ProducersMixin,
+    # SelectorStepsMixin,
+    CalibratorsMixin,
+):
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_columnar.sh")
+
+    def requires(self):
+        reqs = {}
+
+        for channel in ("mu", "e"):
+
+            # control plots with data
+            reqs[f"control_plots_{channel}"] = PlotVariables1D.req(
+                self,
+                config="config_2017",
+                producers=("features",),
+                processes=(f"d{channel}ch",),
+                process_settings=[["scale_signal"]],
+                variables=["*"],
+                categories=(f"{channel}ch",),
+                yscale="log",
+                cms_label="pw",
+            )
+
+            # ML input features
+            reqs[f"ml_inputs_{channel}"] = PlotVariables1D.req(
+                self,
+                config="config_2017",
+                producers=("ml_inputs",),
+                processes=(f"{channel}ch",),
+                # process_settings=[["scale_signal"]],
+                variables=["mli_*"],
+                categories=(f"{channel}ch",),
+                yscale="log",
+                cms_label="simpw",
+            )
+
+            # ML output nodes
+            ml_model = "default"
+            reqs[f"ml_outputs_{channel}"] = PlotVariables1D.req(
+                self,
+                config="config_2017",
+                producers=("ml_inputs",),
+                ml_models=(ml_model,),
+                processes=(f"{channel}ch",),
+                # process_settings=[["scale_signal"]],
+                variables=[f"{ml_model}.*"],
+                categories=(f"{channel}ch",),
+                yscale="log",
+                cms_label="simpw",
+            )
+
+        # ML outputs categorized (TODO)
+
+        return reqs
+
+    def output(self):
+
+        # use the input also as output
+        # (makes it easier to fetch and delete outputs)
+        return self.requires()
+
+    def run(self):
+        pass


### PR DESCRIPTION
The changes (along some minor config changes) are:

- The boosted selection is performed separately again without the btag requirement in order to be able to calculate the btag renormalisation factor correctly
- A jet lepton cleaning is added
- The Selection now returns two types of AK8 jets, some baseline FatJet collection and the HbbJet collection
- A wrapper task (DefaultPlots) is added to conveniently produce a default set of plots