### PR TITLE
Implement analysis instances for SL, DL and merged

### DIFF
--- a/hbw/__init__.py
+++ b/hbw/__init__.py
@@ -3,13 +3,5 @@
 
 from hbw.columnflow_patches import patch_all
 
-__all__ = [
-    "analysis_hbw", "config_2017", "config_2017_limited",
-]
-
-# provisioning imports
-from hbw.config.analysis_hbw import analysis_hbw, config_2017, config_2017_limited
-
-
 # apply cf patches once
 patch_all()

--- a/hbw/analysis/create_analysis.py
+++ b/hbw/analysis/create_analysis.py
@@ -86,12 +86,3 @@ def create_hbw_analysis(
     l17 = config_2017_limited.copy(name="l17", id=112)  # noqa
 
     return analysis_inst
-
-
-# create all relevant analysis instances
-analysis_hbw = create_hbw_analysis("analysis_hbw", 1, tags={"is_sl", "is_dl", "is_resonant", "is_nonresonant"})
-hbw_sl = create_hbw_analysis("hbw_sl", 2, tags={"is_sl", "is_nonresonant"})
-# TODO: commented out for now because otherwise configs are built multiple times
-#       should I move each analysis into a separate file to prevent this?
-# hbw_dl = create_hbw_analysis("hbw_dl", 3, tags={"is_dl", "is_nonresonant"})
-# hbw_res_sl = create_hbw_analysis("hbw_res_sl", 4, tags={"is_sl", "is_resonant"})

--- a/hbw/analysis/hbw_dl.py
+++ b/hbw/analysis/hbw_dl.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+
+"""
+Main analysis object for the nonresonant HH -> bbWW(DL) analysis
+"""
+
+from hbw.analysis.create_analysis import create_hbw_analysis
+
+hbw_dl = create_hbw_analysis("hbw_dl", 3, tags={"is_dl", "is_nonresonant"})

--- a/hbw/analysis/hbw_merged.py
+++ b/hbw/analysis/hbw_merged.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+"""
+Main analysis object for the HH -> bbWW analysis, combining all sub-analyses.
+This analysis inst is mainly used to produce commonly used outputs, e.g. from these tasks
+- cf.GetDatasetLFNs
+- cf.CalibrateEvents
+"""
+
+from hbw.analysis.create_analysis import create_hbw_analysis
+
+hbw_merged = create_hbw_analysis("hbw_merged", 1, tags={"is_sl", "is_dl", "is_resonant", "is_nonresonant"})

--- a/hbw/analysis/hbw_sl.py
+++ b/hbw/analysis/hbw_sl.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+
+"""
+Main analysis object for the nonresonant HH -> bbWW(SL) analysis
+"""
+
+from hbw.analysis.create_analysis import create_hbw_analysis
+
+hbw_sl = create_hbw_analysis("hbw_sl", 3, tags={"is_sl", "is_nonresonant"})

--- a/hbw/config/analysis_hbw.py
+++ b/hbw/config/analysis_hbw.py
@@ -12,68 +12,86 @@ import order as od
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
 
-#
-# the main analysis object
-#
 
-analysis_hbw = od.Analysis(
-    name="analysis_hbw",
-    id=1,
-)
+def create_hbw_analysis(
+    name,
+    id,
+    **kwargs,
+) -> od.Analysis:
 
-# analysis-global versions
-analysis_hbw.set_aux("versions", {
-})
+    #
+    # the main analysis object
+    #
 
-# files of sandboxes that might be required by remote tasks
-# (used in cf.HTCondorWorkflow)
-analysis_hbw.x.bash_sandboxes = [
-    "$CF_BASE/sandboxes/cf.sh",
-    "$CF_BASE/sandboxes/venv_columnar.sh",
-    # "$CF_BASE/sandboxes/venv_ml_tf.sh",
-    "$HBW_BASE/sandboxes/venv_ml_plotting.sh",
-]
+    analysis_inst = od.Analysis(
+        name=name,
+        id=id,
+        **kwargs,
+    )
 
-# cmssw sandboxes that should be bundled for remote jobs in case they are needed
-analysis_hbw.set_aux("cmssw_sandboxes", [
-    # "$CF_BASE/sandboxes/cmssw_default.sh",
-])
+    # analysis-global versions
+    analysis_inst.set_aux("versions", {
+    })
+
+    # files of sandboxes that might be required by remote tasks
+    # (used in cf.HTCondorWorkflow)
+    analysis_inst.x.bash_sandboxes = [
+        "$CF_BASE/sandboxes/cf.sh",
+        "$CF_BASE/sandboxes/venv_columnar.sh",
+        # "$CF_BASE/sandboxes/venv_ml_tf.sh",
+        "$HBW_BASE/sandboxes/venv_ml_plotting.sh",
+    ]
+
+    # cmssw sandboxes that should be bundled for remote jobs in case they are needed
+    analysis_inst.set_aux("cmssw_sandboxes", [
+        # "$CF_BASE/sandboxes/cmssw_default.sh",
+    ])
+
+    # clear the list when cmssw bundling is disabled
+    if not law.util.flag_to_bool(os.getenv("HBW_BUNDLE_CMSSW", "1")):
+        del analysis_inst.x.cmssw_sandboxes[:]
+
+    # config groups for conveniently looping over certain configs
+    # (used in wrapper_factory)
+    analysis_inst.set_aux("config_groups", {})
+
+    #
+    # import campaigns and load configs
+    #
+
+    from hbw.config.config_run2 import add_config
+    import cmsdb.campaigns.run2_2017_nano_v9
+
+    campaign_run2_2017_nano_v9 = cmsdb.campaigns.run2_2017_nano_v9.campaign_run2_2017_nano_v9
+
+    # default config
+    config_2017 = add_config(
+        analysis_inst,
+        campaign_run2_2017_nano_v9.copy(),
+        config_name="config_2017",
+        config_id=2,
+    )
+
+    # config with limited number of files
+    config_2017_limited = add_config(
+        analysis_inst,
+        campaign_run2_2017_nano_v9.copy(),
+        config_name="config_2017_limited",
+        config_id=12,
+        limit_dataset_files=2,
+    )
+
+    # new configs but with shorter names
+    c17 = config_2017.copy(name="c17", id=102)  # noqa
+    l17 = config_2017_limited.copy(name="l17", id=112)  # noqa
+
+    return analysis_inst
 
 
-# clear the list when cmssw bundling is disabled
-if not law.util.flag_to_bool(os.getenv("HBW_BUNDLE_CMSSW", "1")):
-    del analysis_hbw.x.cmssw_sandboxes[:]
-
-# config groups for conveniently looping over certain configs
-# (used in wrapper_factory)
-analysis_hbw.set_aux("config_groups", {})
-
-#
-# import campaigns and load configs
-#
-
-from hbw.config.config_run2 import add_config
-import cmsdb.campaigns.run2_2017_nano_v9
-
-campaign_run2_2017_nano_v9 = cmsdb.campaigns.run2_2017_nano_v9.campaign_run2_2017_nano_v9
-
-# default config
-config_2017 = add_config(
-    analysis_hbw,
-    campaign_run2_2017_nano_v9.copy(),
-    config_name="config_2017",
-    config_id=2,
-)
-
-# config with limited number of files
-config_2017_limited = add_config(
-    analysis_hbw,
-    campaign_run2_2017_nano_v9.copy(),
-    config_name="config_2017_limited",
-    config_id=12,
-    limit_dataset_files=2,
-)
-
-# new configs but with shorter names
-c17 = config_2017.copy(name="c17", id=102)
-l17 = config_2017_limited.copy(name="l17", id=112)
+# create all relevant analysis instances
+analysis_hbw = create_hbw_analysis("analysis_hbw", 1, tags={"is_sl", "is_dl", "is_resonant", "is_nonresonant"})
+hbw_sl = create_hbw_analysis("hbw_sl", 2, tags={"is_sl", "is_nonresonant"})
+# TODO: commented out for now because otherwise configs are built multiple times
+#       should I move each analysis into a separate file to prevent this?
+# hbw_dl = create_hbw_analysis("hbw_dl", 3, tags={"is_dl", "is_nonresonant"})
+# hbw_res_sl = create_hbw_analysis("hbw_res_sl", 4, tags={"is_sl", "is_resonant"})

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Configuration of the 2017 HH -> bbWW analysis.
+Configuration of the Run 2 HH -> bbWW analysis.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from typing import Set
 
 import yaml
 from scinum import Number
+import law
 import order as od
 
 from columnflow.util import DotDict
@@ -21,11 +22,12 @@ from hbw.config.defaults_and_groups import set_config_defaults_and_groups
 from hbw.config.categories import add_categories_selection
 from hbw.config.variables import add_variables
 from hbw.config.datasets import get_dataset_lfns, get_custom_hh_datasets
-from hbw.config.analysis_hbw import analysis_hbw
 from hbw.util import four_vec
 
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
+
+logger = law.logger.get_logger(__name__)
 
 
 def add_config(
@@ -39,7 +41,6 @@ def add_config(
     assert campaign.x.year in [2016, 2017, 2018]
     if campaign.x.year == 2016:
         assert campaign.x.vfp in ["pre", "post"]
-
     # gather campaign data
     year = campaign.x.year
     year2 = year % 100
@@ -55,7 +56,7 @@ def add_config(
     procs = get_root_processes_from_campaign(campaign)
 
     # create a config by passing the campaign, so id and name will be identical
-    cfg = analysis_hbw.add_config(campaign, name=config_name, id=config_id)
+    cfg = analysis.add_config(campaign, name=config_name, id=config_id, tags=analysis.tags)
 
     # use custom get_dataset_lfns function
     cfg.x.get_dataset_lfns = get_dataset_lfns
@@ -73,18 +74,33 @@ def add_config(
     # cfg.add_process(procs.n.ttv)
     # cfg.add_process(procs.n.vv)
     # cfg.add_process(procs.n.vv)
-    cfg.add_process(procs.n.ggHH_kl_0_kt_1_sl_hbbhww)
-    cfg.add_process(procs.n.ggHH_kl_1_kt_1_sl_hbbhww)
-    cfg.add_process(procs.n.ggHH_kl_2p45_kt_1_sl_hbbhww)
-    cfg.add_process(procs.n.ggHH_kl_5_kt_1_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_1_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_0_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_2_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
-    cfg.add_process(procs.n.qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
     cfg.add_process(procs.n.hh_ggf_bbtautau)
+
+    if cfg.has_tag("is_sl") and cfg.has_tag("is_nonresonant"):
+        cfg.add_process(procs.n.ggHH_kl_0_kt_1_sl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_1_kt_1_sl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_2p45_kt_1_sl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_5_kt_1_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_1_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_0_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_2_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
+
+    if cfg.has_tag("is_dl") and cfg.has_tag("is_nonresonant"):
+        cfg.add_process(procs.n.ggHH_kl_0_kt_1_dl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_1_kt_1_dl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_2p45_kt_1_dl_hbbhww)
+        cfg.add_process(procs.n.ggHH_kl_5_kt_1_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_1_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_0_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_1_kl_2_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_0_kl_1_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
+        cfg.add_process(procs.n.qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
 
     # QCD process customization
     cfg.get_process("qcd_mu").label = "QCD Muon enriched"
@@ -167,25 +183,49 @@ def add_config(
         "qcd_bctoe_pt30to80_pythia", "qcd_bctoe_pt80to170_pythia",
         "qcd_bctoe_pt170to250_pythia", "qcd_bctoe_pt250toInf_pythia",
         # TTV, VV -> ignore?; Higgs -> not used in Msc, but would be interesting
-        # Signal
-        # "ggHH_kl_0_kt_1_sl_hbbhww_custom",
-        # "ggHH_kl_1_kt_1_sl_hbbhww_custom",
-        # "ggHH_kl_2p45_kt_1_sl_hbbhww_custom",
-        # "ggHH_kl_5_kt_1_sl_hbbhww_custom",
-        "ggHH_kl_0_kt_1_sl_hbbhww_powheg",
-        "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
-        "ggHH_kl_2p45_kt_1_sl_hbbhww_powheg",
-        "ggHH_kl_5_kt_1_sl_hbbhww_powheg",
-        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
-        "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww_madgraph",
-        "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww_madgraph",
-        "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww_madgraph",
-        "qqHH_CV_1_C2V_2_kl_1_sl_hbbhww_madgraph",
-        "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww_madgraph",
-        "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww_madgraph",
         # HH(bbtautau)
         "hh_ggf_bbtautau_madgraph",
     ]
+
+    if cfg.has_tag("is_sl") and cfg.has_tag("is_nonresonant"):
+        # non-resonant HH -> bbWW(qqlnu) Signal
+        dataset_names += [
+            "ggHH_kl_0_kt_1_sl_hbbhww_powheg",
+            "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+            "ggHH_kl_2p45_kt_1_sl_hbbhww_powheg",
+            "ggHH_kl_5_kt_1_sl_hbbhww_powheg",
+            # custom samples (TODO: should we include a parameter to switch between custom/offical samples?)
+            # "ggHH_kl_0_kt_1_sl_hbbhww_custom",
+            # "ggHH_kl_1_kt_1_sl_hbbhww_custom",
+            # "ggHH_kl_2p45_kt_1_sl_hbbhww_custom",
+            # "ggHH_kl_5_kt_1_sl_hbbhww_custom",
+            "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_2_kl_1_sl_hbbhww_madgraph",
+            "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww_madgraph",
+            "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww_madgraph",
+        ]
+
+    if cfg.has_tag("is_dl") and cfg.has_tag("is_nonresonant"):
+        # non-resonant HH -> bbWW(lnulnu) Signal
+        dataset_names += [
+            "ggHH_kl_0_kt_1_dl_hbbhww_powheg",
+            "ggHH_kl_1_kt_1_dl_hbbhww_powheg",
+            "ggHH_kl_2p45_kt_1_dl_hbbhww_powheg",
+            "ggHH_kl_5_kt_1_dl_hbbhww_powheg",
+            "qqHH_CV_1_C2V_1_kl_1_dl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_1_kl_0_dl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_1_kl_2_dl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_0_kl_1_dl_hbbhww_madgraph",
+            "qqHH_CV_1_C2V_2_kl_1_dl_hbbhww_madgraph",
+            "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww_madgraph",
+            "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww_madgraph",
+        ]
+    if cfg.has_tag("is_resonant"):
+        logger.warning(f"For analysis {analysis.name}: resonant samples still needs to be implemented")
+
     for dataset_name in dataset_names:
         dataset = cfg.add_dataset(campaign.get_dataset(dataset_name))
 
@@ -196,6 +236,7 @@ def add_config(
                     info.n_files = limit_dataset_files
 
         # add aux info to datasets
+        # NOTE: we should maybe change them to tags
         if dataset.name.startswith(("st", "tt")):
             dataset.x.has_top = True
         if dataset.name.startswith("tt"):
@@ -203,12 +244,14 @@ def add_config(
         if dataset.name.startswith("qcd"):
             dataset.x.is_qcd = True
         if "HH" in dataset.name and "hbbhww" in dataset.name:
+            # TODO: the is_hbw tag is used at times were we should ask for is_hbw_sl
             dataset.x.is_hbw = True
 
         if dataset.name.startswith("qcd") or dataset.name.startswith("qqHH_"):
             dataset.x.skip_scale = True
             dataset.x.skip_pdf = True
 
+    # TODO: this should be configured as part of the Selector inst
     cfg.x.selector_step_labels = {
         "Jet": r"$N_{jets}^{AK4} \geq 3$",
         "Lepton": r"$N_{lepton} \geq 1$",
@@ -512,9 +555,6 @@ def add_config(
 
         # met phi corrector
         "met_phi_corr": (f"{json_mirror}/POG/JME/{year}{corr_postfix}_UL/met.json.gz", "v1"),
-
-        # hh-btag repository (lightweight) with TF saved model directories
-        "hh_btag_repo": ("https://github.com/hh-italian-group/HHbtag/archive/1dc426053418e1cab2aec021802faf31ddf3c5cd.tar.gz", "v1"),  # noqa
     })
 
     # external files with more complex year dependence
@@ -542,6 +582,8 @@ def add_config(
     }))
 
     # columns to keep after certain steps
+    # TODO: selector-dependent columns should either use the is_sl / is_dl tag or
+    #       be implemented as part of the selectors itself (e.g. only SL needs the Lightjet column)
     cfg.x.keep_columns = DotDict.wrap({
         "cf.MergeSelectionMasks": {
             "mc_weight", "normalization_weight", "process_id", "category_ids", "cutflow.*",
@@ -599,25 +641,25 @@ def add_config(
         if not dataset.x("skip_pdf", False):
             dataset.x.event_weights["normalized_pdf_weight"] = get_shifts("pdf")
 
-    dev_version = "dev1"
-    prod_version = "prod1"
-
     def reduce_version(cls, inst, params):
-        version = dev_version
-        if params.get("selector") == "default":
-            version = prod_version
+        # per default, use the version set on the command line
+        version = inst.version  # same as params.get("version") ?
+
+        if params.get("selector") == "sl_v1":
+            # use a fixed version for the sl_v1 selector
+            version = "sl_v1"
 
         return version
 
     # Version of required tasks
     cfg.x.versions = {
         "cf.CalibrateEvents": "common1",
-        # "cf.SelectEvents": reduce_version,
-        # "cf.MergeSelectionStats": reduce_version,
-        # "cf.MergeSelectionMasks": reduce_version,
-        # "cf.ReduceEvents": reduce_version,
-        # "cf.MergeReductionStats": reduce_version,
-        # "cf.MergeReducedEvents": reduce_version,
+        "cf.SelectEvents": reduce_version,
+        "cf.MergeSelectionStats": reduce_version,
+        "cf.MergeSelectionMasks": reduce_version,
+        "cf.ReduceEvents": reduce_version,
+        "cf.MergeReductionStats": reduce_version,
+        "cf.MergeReducedEvents": reduce_version,
     }
 
     # add categories

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -251,16 +251,6 @@ def add_config(
             dataset.x.skip_scale = True
             dataset.x.skip_pdf = True
 
-    # TODO: this should be configured as part of the Selector inst
-    cfg.x.selector_step_labels = {
-        "Jet": r"$N_{jets}^{AK4} \geq 3$",
-        "Lepton": r"$N_{lepton} \geq 1$",
-        "VetoLepton": r"$N_{lepton}^{veto} \leq 1$",
-        "Bjet": r"$N_{jets}^{BTag} \geq 1$",
-        "FatJet": r"$N_{H \rightarrow bb}^{AK8} \geq 1$",
-        "Boosted": r"$N_{jets}^{AK4} \geq 1$",
-    }
-
     # lumi values in inverse pb
     # https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun2?rev=2#Combination_and_correlations
     if year == 2016:

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -14,6 +14,7 @@ def default_ml_model(cls, container, task_params):
     # the ml_model parameter is only used by `MLTraining` and `MLEvaluation`, therefore use some default
     # NOTE: default_ml_model does not work for the MLTraining task
     if cls.task_family in ("cf.MLTraining", "cf.MLEvaulation"):
+        # TODO: we might want to distinguish between two default ML models (sl vs dl)
         default_ml_model = "dense_default"
 
     # check if task is using an inference model; if that's the case, use the default set in the model
@@ -35,6 +36,7 @@ def default_producers(cls, container, task_params):
     """ Default producers chosen based on the Inference model and the ML Model """
 
     # per default, use the ml_inputs and event_weights
+    # TODO: we might need two ml_inputs producers in the future (sl vs dl)
     default_producers = ["ml_inputs", "event_weights"]
 
     # check if a ml_model has been set
@@ -67,30 +69,50 @@ def default_producers(cls, container, task_params):
 def set_config_defaults_and_groups(config_inst):
     """ Configuration function that sets all the defaults and groups in the config_inst """
 
-    # default calibrator, selector, producer, ml model and inference model
+    # define the default dataset and process based on the analysis tags
+    signal_tag = "sl" if config_inst.has_tag("is_sl") else "dl"
+    default_signal_process = f"ggHH_kl_1_kt_1_{signal_tag}_hbbhww"
+    signal_generator = "powheg"
+
+    if config_inst.has_tag("resonant"):
+        signal_tag = f"res_{signal_tag}"
+        # for resonant, rely on the law.cfg to define the default signal process (NOTE: might change in the future)
+        default_signal_process = law.config.get_expanded("analysis", "default_dataset")
+        signal_generator = "madgraph"
+
+    #
+    # Defaults
+    #
+
+    # TODO: the default dataset is currently still being set up by the law.cfg
+    config_inst.x.default_dataset = default_signal_dataset = f"{default_signal_process}_{signal_generator}"
     config_inst.x.default_calibrator = "skip_jecunc"
-    # TODO: make configurable via law.cfg?
-    config_inst.x.default_selector = "sl"
+    config_inst.x.default_selector = f"{signal_tag}"
     config_inst.x.default_producer = default_producers
     config_inst.x.default_ml_model = default_ml_model
     config_inst.x.default_inference_model = "default"
     config_inst.x.default_categories = ["incl"]
 
+    #
+    # Groups
+    #
+
     # process groups for conveniently looping over certain processs
     # (used in wrapper_factory and during plotting)
     config_inst.x.process_groups = {
         "all": ["*"],
-        "default": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st", "w_lnu", "dy_lep"],
-        "with_qcd": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "qcd", "st", "w_lnu", "dy_lep"],
-        "much": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "qcd_mu", "st", "w_lnu", "dy_lep"],
-        "ech": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "qcd_ele", "st", "w_lnu", "dy_lep"],
+        "default": [default_signal_process, "tt", "st", "w_lnu", "dy_lep"],
+        "with_qcd": [default_signal_process, "tt", "qcd", "st", "w_lnu", "dy_lep"],
+        "much": [default_signal_process, "tt", "qcd_mu", "st", "w_lnu", "dy_lep"],
+        "ech": [default_signal_process, "tt", "qcd_ele", "st", "w_lnu", "dy_lep"],
         "inference": ["ggHH_*", "tt", "st", "w_lnu", "dy_lep", "qcd_*"],
-        "ml": ["ggHH_kl_1_*", "tt", "st", "w_lnu", "dy_lep"],
-        "ml_test": ["ggHH_kl_1_*", "st", "w_lnu"],
-        "test": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt_sl"],
-        "small": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st"],
+        "k2v": ["qqHH_*", "tt", "st", "w_lnu", "dy_lep", "qcd_*"],
+        "ml": [default_signal_process, "tt", "st", "w_lnu", "dy_lep"],
+        "ml_test": [default_signal_process, "st", "w_lnu"],
+        "test": [default_signal_process, "tt_sl"],
+        "small": [default_signal_process, "tt", "st"],
         "bkg": ["tt", "st", "w_lnu", "dy_lep"],
-        "signal": ["ggHH_*", "qqHH"], "gghh": ["ggHH_*"], "qqhh": ["qqHH_*"],
+        "signal": ["ggHH_*", "qqHH_*"], "gghh": ["ggHH_*"], "qqhh": ["qqHH_*"],
     }
     config_inst.x.process_groups["dmuch"] = ["data_mu"] + config_inst.x.process_groups["much"]
     config_inst.x.process_groups["dech"] = ["data_e"] + config_inst.x.process_groups["ech"]
@@ -99,25 +121,26 @@ def set_config_defaults_and_groups(config_inst):
     # (used in wrapper_factory and during plotting)
     config_inst.x.dataset_groups = {
         "all": ["*"],
-        "default": ["ggHH_kl_1*", "tt_*", "qcd_*", "st_*", "dy_*", "w_lnu_*"],
+        "default": [default_signal_dataset, "tt_*", "qcd_*", "st_*", "dy_*", "w_lnu_*"],
         "inference": ["ggHH_*", "tt_*", "qcd_*", "st_*", "dy_*", "w_lnu_*"],
-        "test": ["ggHH_kl_1*", "tt_sl_powheg"],
-        "small": ["ggHH_kl_1*", "tt_*", "st_*"],
+        "test": [default_signal_dataset, "tt_sl_powheg"],
+        "small": [default_signal_dataset, "tt_*", "st_*"],
         "bkg": ["tt_*", "st_*", "w_lnu_*", "dy_*"],
         "tt": ["tt_*"], "st": ["st_*"], "w": ["w_lnu_*"], "dy": ["dy_*"],
         "qcd": ["qcd_*"], "qcd_mu": ["qcd_mu*"], "qcd_ele": ["qcd_em*", "qcd_bctoe*"],
         "signal": ["ggHH_*", "qqHH_*"], "gghh": ["ggHH_*"], "qqhh": ["qqHH_*"],
-        "ml": ["ggHH_kl_1*", "tt_*", "st_*", "dy_*", "w_lnu_*"],
+        "ml": [default_signal_dataset, "tt_*", "st_*", "dy_*", "w_lnu_*"],
     }
 
     # category groups for conveniently looping over certain categories
     # (used during plotting)
-    config_inst.x.category_groups = {
-        "much": ["1mu", "1mu__resolved", "1mu__boosted"],
-        "ech": ["1e", "1e__resolved", "1e__boosted"],
-        "default": ["incl", "1e", "1mu"],
-        "test": ["incl", "1e"],
-    }
+    if signal_tag == "sl":
+        config_inst.x.category_groups = {
+            "much": ["1mu", "1mu__resolved", "1mu__boosted"],
+            "ech": ["1e", "1e__resolved", "1e__boosted"],
+            "default": ["incl", "1e", "1mu"],
+            "test": ["incl", "1e"],
+        }
 
     # variable groups for conveniently looping over certain variables
     # (used during plotting)
@@ -135,6 +158,7 @@ def set_config_defaults_and_groups(config_inst):
 
     # selector step groups for conveniently looping over certain steps
     # (used in cutflow tasks)
+    # NOTE: this could be added as part of the selector init itself
     config_inst.x.selector_step_groups = {
         "resolved": ["Trigger", "Lepton", "VetoLepton", "Jet", "Bjet", "VetoTau"],
         "boosted": ["Trigger", "Lepton", "VetoLepton", "FatJet", "Boosted"],
@@ -144,12 +168,13 @@ def set_config_defaults_and_groups(config_inst):
     }
 
     # plotting settings groups
+    # (used in plotting)
     config_inst.x.general_settings_groups = {
         "test1": {"p1": True, "p2": 5, "p3": "text", "skip_legend": True},
         "default_norm": {"shape_norm": True, "yscale": "log"},
     }
     config_inst.x.process_settings_groups = {
-        "default": {"ggHH_kl_1_kt_1_sl_hbbhww": {"scale": 2000, "unstack": True}},
+        "default": {default_signal_process: {"scale": 2000, "unstack": True}},
         "unstack_all": {proc.name: {"unstack": True} for proc in config_inst.processes},
         "unstack_signal": {proc.name: {"unstack": True} for proc in config_inst.processes if "HH" in proc.name},
         "scale_signal": {
@@ -167,7 +192,7 @@ def set_config_defaults_and_groups(config_inst):
         },
     }
 
-    # CSPs
+    # CSP (calibrator, selector, producer) groups
     config_inst.x.producer_groups = {
         "mli": ["ml_inputs", "event_weights"],
         "mlo": ["ml_dense_default", "event_weights"],

--- a/hbw/production/prepare_objects.py
+++ b/hbw/production/prepare_objects.py
@@ -107,14 +107,6 @@ def prepare_objects(self: Producer, events: ak.Array, results: SelectionResult =
         bjet_indices = ak.argsort(events.Jet.btagDeepFlavB, axis=-1, ascending=False)
         events = set_ak_column(events, "Bjet", events.Jet[bjet_indices[:, :2]])
 
-    if "Lightjet" not in events.fields and "Jet" in events.fields:
-        logger.warning("Lightjet collection is missing: will be defined using the Jet collection")
-        # define lightjets as all non b-jets, pt-sorted
-        bjet_indices = ak.argsort(events.Jet.btagDeepFlavB, axis=-1, ascending=False)
-        lightjets = events.Jet[bjet_indices[:, 2:]]
-        lightjets = lightjets[ak.argsort(lightjets.pt, axis=-1, ascending=False)]
-        events = set_ak_column(events, "Lightjet", lightjets)
-
     if "VetoLepton" not in events.fields and "VetoElectron" in events.fields and "VetoMuon" in events.fields:
         # combine VetoElectron and VetoMuon into a single object (VetoLepton)
         lepton_fields = set(events.VetoMuon.fields).intersection(events.VetoElectron.fields)

--- a/hbw/selection/categories.py
+++ b/hbw/selection/categories.py
@@ -42,7 +42,6 @@ def catid_boosted(self: Selector, events: ak.Array, **kwargs) -> ak.Array:
     Categorization of events in the boosted category: presence of at least 1 AK8 jet fulfilling
     requirements given by the Selector called in SelectEvents
     """
-    # TODO: this categorization skips the dR requirement between the HbbJet and the AK4 jet
     return (ak.sum(events.Jet.pt > 0, axis=-1) >= 1) & (ak.sum(events.HbbJet.pt > 0, axis=-1) >= 1)
 
 

--- a/hbw/selection/sl.py
+++ b/hbw/selection/sl.py
@@ -70,7 +70,7 @@ def sl_jet_selection(
 
     # build and return selection results plus new columns
     return events, SelectionResult(
-        steps={"Jet": jet_sel, "Bjet": btag_sel},
+        steps={"Jet": jet_sel, "Bjet": btag_sel, "Resolved": (jet_sel & btag_sel)},
         objects={
             "Jet": {
                 "LooseJet": masked_sorted_indices(jet_mask_loose, events.Jet.pt),
@@ -298,6 +298,24 @@ lep_27 = sl.derive("sl_lep_27", cls_dict={"ele_pt": 27, "mu_pt": 27})
 
 @sl.init
 def sl_init(self: Selector) -> None:
+    # define mapping from selector step to labels used in cutflow plots
+    self.config_inst.x("selector_step_labels", {}).update({
+        "Lepton": r"$N_{lepton} \geq 1$",
+        "VetoLepton": r"$N_{lepton}^{veto} \leq 1$",
+        "VetoTau": r"$N_{\tau}^{veto} = 0$",
+        "Muon": r"$N_{\mu} \geq 1$ and $N_{e} \geq 0$",  # NOTE: Muon and Electron steps
+        "Electron": r"$N_{\mu} \geq 0$ and $N_{e} \geq 1$",  # shouldn't be used together
+        "TriggerAndLep": r"($N_{e} \geq 1$ and e-trigger) or ($N_{\mu} \geq 1$ and \mu-trigger) ",
+        "Jet": r"$N_{jets}^{AK4} \geq 3$",
+        "Bjet": r"$N_{jets}^{BTag} \geq 1$",
+        "Resolved": r"$N_{jets}^{AK4} \geq 3$ and $N_{jets}^{BTag} \geq 1$",
+        "HbbJet": r"$N_{H \rightarrow bb}^{AK8} \geq 1$",
+        "VBFJetPair": r"$N_{VBFJetPair}^{AK4} \geq 1$",
+        "ResolvedOrBoosted": (
+            r"($N_{jets}^{AK4} \geq 3$ and $N_{jets}^{BTag} \geq 1$) or $N_{H \rightarrow bb}^{AK8} \geq 1$",
+        ),
+    })
+
     if self.config_inst.x("do_cutflow_features", False):
         self.uses.add(cutflow_features)
         self.produces.add(cutflow_features)

--- a/hbw/selection/sl.py
+++ b/hbw/selection/sl.py
@@ -299,20 +299,23 @@ lep_27 = sl.derive("sl_lep_27", cls_dict={"ele_pt": 27, "mu_pt": 27})
 @sl.init
 def sl_init(self: Selector) -> None:
     # define mapping from selector step to labels used in cutflow plots
-    self.config_inst.x("selector_step_labels", {}).update({
+    self.config_inst.x.selector_step_labels = self.config_inst.x("selector_step_labels", {})
+    self.config_inst.x.selector_step_labels.update({
+        # NOTE: many of these labels are too long for the cf.PlotCutflow task
         "Lepton": r"$N_{lepton} \geq 1$",
         "VetoLepton": r"$N_{lepton}^{veto} \leq 1$",
         "VetoTau": r"$N_{\tau}^{veto} = 0$",
         "Muon": r"$N_{\mu} \geq 1$ and $N_{e} \geq 0$",  # NOTE: Muon and Electron steps
         "Electron": r"$N_{\mu} \geq 0$ and $N_{e} \geq 1$",  # shouldn't be used together
-        "TriggerAndLep": r"($N_{e} \geq 1$ and e-trigger) or ($N_{\mu} \geq 1$ and \mu-trigger) ",
+        "TriggerAndLep": "Trigger matches Lepton Channel",
         "Jet": r"$N_{jets}^{AK4} \geq 3$",
         "Bjet": r"$N_{jets}^{BTag} \geq 1$",
         "Resolved": r"$N_{jets}^{AK4} \geq 3$ and $N_{jets}^{BTag} \geq 1$",
         "HbbJet": r"$N_{H \rightarrow bb}^{AK8} \geq 1$",
         "VBFJetPair": r"$N_{VBFJetPair}^{AK4} \geq 1$",
         "ResolvedOrBoosted": (
-            r"($N_{jets}^{AK4} \geq 3$ and $N_{jets}^{BTag} \geq 1$) or $N_{H \rightarrow bb}^{AK8} \geq 1$",
+            r"($N_{jets}^{AK4} \geq 3$ and $N_{jets}^{BTag} \geq 1$) "
+            r"or $N_{H \rightarrow bb}^{AK8} \geq 1$"
         ),
     })
 

--- a/law.cfg
+++ b/law.cfg
@@ -17,10 +17,11 @@ hbw.tasks.wrapper
 law: INFO
 luigi-interface: INFO
 gfal2: WARNING
+
 [analysis]
 
-default_analysis: hbw.config.analysis_hbw.analysis_hbw
-default_config: config_2017_limited
+default_analysis: hbw.analysis.hbw_merged.hbw_merged
+default_config: c17
 default_dataset: ggHH_kl_1_kt_1_sl_hbbhww_powheg
 
 production_modules: columnflow.production.{categories,processes,pileup,normalization,seeds}, hbw.production.{weights,features,ml_inputs,categories,gen_hbw_decay}

--- a/law.dl.cfg
+++ b/law.dl.cfg
@@ -1,0 +1,11 @@
+[core]
+
+# inherit from the main analysis configuration file
+inherit: $HBW_BASE/law.cfg
+
+[analysis]
+
+# override defaults for the SL analysis
+default_analysis: hbw.analysis.hbw_dl.hbw_dl
+default_config: c17
+default_dataset: ggHH_kl_1_kt_1_dl_hbbhww_powheg

--- a/law.dl.nocert.cfg
+++ b/law.dl.nocert.cfg
@@ -1,0 +1,11 @@
+[core]
+
+# inherit from the analysis configuration file, allowing to use datasets
+# stored at DESY without a Grid certificate
+inherit: $HBW_BASE/law.nocert.cfg
+
+[analysis]
+
+default_analysis: hbw.analysis.hbw_dl.hbw_dl
+default_config: c17
+default_dataset: ggHH_kl_1_kt_1_dl_hbbhww_powheg

--- a/law.nocert.cfg
+++ b/law.nocert.cfg
@@ -2,7 +2,7 @@
 
 [core]
 
-# inherit from the analysis configuration file
+# inherit from the main analysis configuration file
 inherit: $HBW_BASE/law.cfg
 
 

--- a/law.sl.cfg
+++ b/law.sl.cfg
@@ -1,0 +1,11 @@
+[core]
+
+# inherit from the main analysis configuration file
+inherit: $HBW_BASE/law.cfg
+
+[analysis]
+
+# override defaults for the SL analysis
+default_analysis: hbw.analysis.hbw_sl.hbw_sl
+default_config: c17
+default_dataset: ggHH_kl_1_kt_1_sl_hbbhww_powheg

--- a/law.sl.nocert.cfg
+++ b/law.sl.nocert.cfg
@@ -1,0 +1,11 @@
+[core]
+
+# inherit from the analysis configuration file, allowing to use datasets
+# stored at DESY without a Grid certificate
+inherit: $HBW_BASE/law.nocert.cfg
+
+[analysis]
+
+default_analysis: hbw.analysis.hbw_sl.hbw_sl
+default_config: c17
+default_dataset: ggHH_kl_1_kt_1_sl_hbbhww_powheg

--- a/setup.sh
+++ b/setup.sh
@@ -78,6 +78,7 @@ setup_hbw() {
 		export_and_save CF_SCHEDULER_PORT "8082"
             fi
             query HBW_BUNDLE_CMSSW "Install and bundle CMSSW sandboxes for job submission?" "True"
+	    query HBW_LAW_CONFIG "Name of the file to be used as law config (must be located in $HBW_BASE)" "law.sl.nocert.cfg"
 	}
 	cf_setup_interactive "${CF_SETUP_NAME}" "${HBW_BASE}/.setups/${CF_SETUP_NAME}.sh" || return "$?"
     fi
@@ -87,7 +88,7 @@ setup_hbw() {
     export CF_VENV_BASE="${CF_VENV_BASE:-${CF_SOFTWARE_BASE}/venvs}"
     export CF_CMSSW_BASE="${CF_CMSSW_BASE:-${CF_SOFTWARE_BASE}/cmssw}"
     export CF_CI_JOB="$( [ "${GITHUB_ACTIONS}" = "true" ] && echo 1 || echo 0 )"
-
+    export HBW_LAW_CONFIG="${HBW_LAW_CONFIG:-law.sl.nocert.cfg}"
 
     #
     # common variables
@@ -119,7 +120,7 @@ setup_hbw() {
     #
 
     export LAW_HOME="${HBW_BASE}/.law"
-    export LAW_CONFIG_FILE="${HBW_BASE}/law.cfg"
+    export LAW_CONFIG_FILE="${HBW_BASE}/${HBW_LAW_CONFIG}"
     # export LAW_CONFIG_FILE="${HBW_BASE}/law.nocert.cfg"
 
     if which law &> /dev/null; then


### PR DESCRIPTION
**Draft**

This PR separates each of the sub-analyses by implementing new analysis instances. Each of the analysis inst needs to be initialized in a separate file to prevent having to initialize all analysis instances for each task call.

For each analysis, there are two law.cfg files that can be used to set the {analysis, config, dataset} defaults approprately
- law.sl.cfg (for users with Grid certificate)
- law.sl.nocert.cfg (for users wihout Grid certificate)
(analogous for dl: resonant is not yet included)

The law config file is chosen based on the $HBW_LAW_CONFIG parameter, which can be set interactively when setting up the analysis or by adding it to the $HBW_BASE/.setups/<name>.sh file

NOTE: with this PR, the name of the analysis and config is changed, which means that previously produced task outputs will no longer be recognized (or all the output paths would need to be renamed).
We should decide on a consistent naming scheme now such that this will not happen again.
