### PR TITLE
Fix event weights

### DIFF
--- a/hbw/analysis/hbw_sl.py
+++ b/hbw/analysis/hbw_sl.py
@@ -6,4 +6,11 @@ Main analysis object for the nonresonant HH -> bbWW(SL) analysis
 
 from hbw.analysis.create_analysis import create_hbw_analysis
 
-hbw_sl = create_hbw_analysis("hbw_sl", 3, tags={"is_sl", "is_nonresonant"})
+hbw_sl = create_hbw_analysis(
+    "hbw_sl", 3,
+    tags={
+        "is_sl",
+        "is_nonresonant",
+        # "custom_signals",
+    },
+)

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Set
 
 import yaml
 from scinum import Number

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -188,16 +188,22 @@ def add_config(
 
     if cfg.has_tag("is_sl") and cfg.has_tag("is_nonresonant"):
         # non-resonant HH -> bbWW(qqlnu) Signal
+        if cfg.has_tag("custom_signals"):
+            dataset_names += [
+                "ggHH_kl_0_kt_1_sl_hbbhww_custom",
+                "ggHH_kl_1_kt_1_sl_hbbhww_custom",
+                "ggHH_kl_2p45_kt_1_sl_hbbhww_custom",
+                "ggHH_kl_5_kt_1_sl_hbbhww_custom",
+            ]
+        else:
+            dataset_names += [
+                "ggHH_kl_0_kt_1_sl_hbbhww_powheg",
+                "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+                "ggHH_kl_2p45_kt_1_sl_hbbhww_powheg",
+                "ggHH_kl_5_kt_1_sl_hbbhww_powheg",
+            ]
+
         dataset_names += [
-            "ggHH_kl_0_kt_1_sl_hbbhww_powheg",
-            "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
-            "ggHH_kl_2p45_kt_1_sl_hbbhww_powheg",
-            "ggHH_kl_5_kt_1_sl_hbbhww_powheg",
-            # custom samples (TODO: should we include a parameter to switch between custom/offical samples?)
-            # "ggHH_kl_0_kt_1_sl_hbbhww_custom",
-            # "ggHH_kl_1_kt_1_sl_hbbhww_custom",
-            # "ggHH_kl_2p45_kt_1_sl_hbbhww_custom",
-            # "ggHH_kl_5_kt_1_sl_hbbhww_custom",
             "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
             "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww_madgraph",
             "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww_madgraph",
@@ -255,6 +261,13 @@ def add_config(
                 dataset.add_tag("is_hbw_dl")
 
         if dataset.name.startswith("qcd") or dataset.name.startswith("qqHH_"):
+            dataset.x.skip_scale = True
+            dataset.x.skip_pdf = True
+            dataset.add_tag("skip_scale")
+            dataset.add_tag("skip_pdf")
+
+        if dataset.has_tag("is_hbw") and "custom" in dataset.name:
+            # No PDF weights and 6 scale weights in custom HH samples
             dataset.x.skip_scale = True
             dataset.x.skip_pdf = True
             dataset.add_tag("skip_scale")

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -439,7 +439,8 @@ def add_config(
     cfg.x.muon_sf_names = ("NUM_TightRelIso_DEN_TightIDandIPCut", f"{year}{corr_postfix}_UL")
 
     # helper to add column aliases for both shifts of a source
-    def add_aliases(shift_source: str, aliases: Set[str], selection_dependent: bool):
+    # TODO: switch to the columnflow function (but what happened to *selection_dependent*?)
+    def add_shift_aliases(shift_source: str, aliases: dict[str], selection_dependent: bool):
 
         for direction in ["up", "down"]:
             shift = cfg.get_shift(od.Shift.join_name(shift_source, direction))
@@ -459,22 +460,28 @@ def add_config(
     cfg.add_shift(name="hdamp_down", id=4, type="shape", tags={"disjoint_from_nominal"})
     cfg.add_shift(name="minbias_xs_up", id=7, type="shape")
     cfg.add_shift(name="minbias_xs_down", id=8, type="shape")
-    add_aliases("minbias_xs", {"pu_weight": "pu_weight_{name}"}, selection_dependent=False)
+    add_shift_aliases(
+        "minbias_xs",
+        {
+            "pu_weight": "pu_weight_{name}",
+            "normalized_pu_weight": "normalized_pu_weight_{name}",
+        },
+        selection_dependent=False)
     cfg.add_shift(name="top_pt_up", id=9, type="shape")
     cfg.add_shift(name="top_pt_down", id=10, type="shape")
-    add_aliases("top_pt", {"top_pt_weight": "top_pt_weight_{direction}"}, selection_dependent=False)
+    add_shift_aliases("top_pt", {"top_pt_weight": "top_pt_weight_{direction}"}, selection_dependent=False)
 
     cfg.add_shift(name="e_sf_up", id=40, type="shape")
     cfg.add_shift(name="e_sf_down", id=41, type="shape")
     cfg.add_shift(name="e_trig_sf_up", id=42, type="shape")
     cfg.add_shift(name="e_trig_sf_down", id=43, type="shape")
-    add_aliases("e_sf", {"electron_weight": "electron_weight_{direction}"}, selection_dependent=False)
+    add_shift_aliases("e_sf", {"electron_weight": "electron_weight_{direction}"}, selection_dependent=False)
 
     cfg.add_shift(name="mu_sf_up", id=50, type="shape")
     cfg.add_shift(name="mu_sf_down", id=51, type="shape")
     cfg.add_shift(name="mu_trig_sf_up", id=52, type="shape")
     cfg.add_shift(name="mu_trig_sf_down", id=53, type="shape")
-    add_aliases("mu_sf", {"muon_weight": "muon_weight_{direction}"}, selection_dependent=False)
+    add_shift_aliases("mu_sf", {"muon_weight": "muon_weight_{direction}"}, selection_dependent=False)
 
     btag_uncs = [
         "hf", "lf", f"hfstats1_{year}", f"hfstats2_{year}",
@@ -483,7 +490,7 @@ def add_config(
     for i, unc in enumerate(btag_uncs):
         cfg.add_shift(name=f"btag_{unc}_up", id=100 + 2 * i, type="shape")
         cfg.add_shift(name=f"btag_{unc}_down", id=101 + 2 * i, type="shape")
-        add_aliases(
+        add_shift_aliases(
             f"btag_{unc}",
             {
                 "normalized_btag_weight": f"normalized_btag_weight_{unc}_" + "{direction}",
@@ -502,8 +509,8 @@ def add_config(
     cfg.add_shift(name="pdf_down", id=208, type="shape")
 
     for unc in ["mur", "muf", "murf_envelope", "pdf"]:
-        # add_aliases(unc, {f"{unc}_weight": f"{unc}_weight_" + "{direction}"}, selection_dependent=False)
-        add_aliases(
+        # add_shift_aliases(unc, {f"{unc}_weight": f"{unc}_weight_" + "{direction}"}, selection_dependent=False)
+        add_shift_aliases(
             unc,
             {f"normalized_{unc}_weight": f"normalized_{unc}_weight_" + "{direction}"},
             selection_dependent=False,
@@ -515,7 +522,7 @@ def add_config(
         idx = all_jec_sources.index(jec_source)
         cfg.add_shift(name=f"jec_{jec_source}_up", id=5000 + 2 * idx, type="shape")
         cfg.add_shift(name=f"jec_{jec_source}_down", id=5001 + 2 * idx, type="shape")
-        add_aliases(
+        add_shift_aliases(
             f"jec_{jec_source}",
             {"Jet.pt": "Jet.pt_{name}", "Jet.mass": "Jet.mass_{name}"},
             selection_dependent=True,
@@ -523,7 +530,7 @@ def add_config(
 
     cfg.add_shift(name="jer_up", id=6000, type="shape", tags={"selection_dependent"})
     cfg.add_shift(name="jer_down", id=6001, type="shape", tags={"selection_dependent"})
-    add_aliases("jer", {"Jet.pt": "Jet.pt_{name}", "Jet.mass": "Jet.mass_{name}"}, selection_dependent=True)
+    add_shift_aliases("jer", {"Jet.pt": "Jet.pt_{name}", "Jet.mass": "Jet.mass_{name}"}, selection_dependent=True)
 
     def make_jme_filename(jme_aux, sample_type, name, era=None):
         """
@@ -628,8 +635,10 @@ def add_config(
 
     # NOTE: which to use, njet_btag_weight or btag_weight?
     cfg.x.event_weights["normalized_btag_weight"] = get_shifts(*(f"btag_{unc}" for unc in btag_uncs))
-    # TODO: fix pu_weight; takes way too large values (from 0 to 160)
-    # cfg.x.event_weights["normalized_pu_weight"] = get_shifts("minbias_xs")
+    cfg.x.event_weights["normalized_pu_weight"] = get_shifts("minbias_xs")
+    cfg.x.event_weights["electron_weight"] = get_shifts("e_sf")
+    cfg.x.event_weights["muon_weight"] = get_shifts("mu_sf")
+
     for dataset in cfg.datasets:
         dataset.x.event_weights = DotDict()
         if not dataset.has_tag("skip_scale"):

--- a/hbw/config/cutflow_variables.py
+++ b/hbw/config/cutflow_variables.py
@@ -122,6 +122,26 @@ def add_cutflow_variables(config: od.Config) -> None:
         x_title=r"max($\Delta R$ (HbbJet 1, AK4 jets))",
     )
 
+    # Pileup variables
+    config.add_variable(
+        name="cf_npvs",
+        expression="cutflow.npvs",
+        binning=(101, -.5, 100.5),
+        x_title="Number of reconstructed primary vertices",
+    )
+    config.add_variable(
+        name="cf_npu",
+        expression="cutflow.npu",
+        binning=(101, -.5, 100.5),
+        x_title="Number of pileup interactions",
+    )
+    config.add_variable(
+        name="cf_npu_true",
+        expression="cutflow.npu_true",
+        binning=(101, -.5, 100.5),
+        x_title="True mean number of poisson distribution from which number of interactions has been sampled",
+    )
+
 
 @call_once_on_config()
 def add_gen_variables(config: od.Config) -> None:

--- a/hbw/config/datasets.py
+++ b/hbw/config/datasets.py
@@ -22,8 +22,8 @@ def get_custom_hh_datasets(
         keys=[
             "chhh0",
         ],
-        n_files=26,
-        n_events=392598,
+        n_files=2,
+        n_events=493996,
         aux={"custom": True},
     )
 
@@ -34,8 +34,8 @@ def get_custom_hh_datasets(
         keys=[
             "chhh1",
         ],
-        n_files=24,
-        n_events=399994,
+        n_files=2,
+        n_events=498499,
         aux={"custom": True},
     )
 
@@ -46,8 +46,8 @@ def get_custom_hh_datasets(
         keys=[
             "chhh2p45",
         ],
-        n_files=40,
-        n_events=399996,
+        n_files=2,
+        n_events=498496,
         aux={"custom": True},
     )
 
@@ -58,8 +58,8 @@ def get_custom_hh_datasets(
         keys=[
             "chhh5",
         ],
-        n_files=28,
-        n_events=395996,
+        n_files=2,
+        n_events=496495,
         aux={"custom": True},
     )
 

--- a/hbw/ml/base.py
+++ b/hbw/ml/base.py
@@ -17,7 +17,6 @@ import order as od
 from columnflow.ml import MLModel
 from columnflow.util import maybe_import, dev_sandbox, DotDict
 from columnflow.columnar_util import Route, set_ak_column, remove_ak_column
-from columnflow.tasks.selection import MergeSelectionStatsWrapper
 
 from hbw.util import log_memory
 from hbw.ml.helper import assign_dataset_to_process, predict_numpy_on_batch
@@ -88,19 +87,12 @@ class MLClassifierBase(MLModel):
                 )
 
     def requires(self, task: law.Task) -> str:
-        # TODO: either remove or include some MLStats task
-        # add selection stats to requires; NOTE: not really used at the moment
-        return MergeSelectionStatsWrapper.req(
-            task,
-            shifts="nominal",
-            configs=self.config_inst.name,
-            datasets=self.dataset_names,
-        )
+        # Custom requirements (none currently)
+        return {}
 
     def sandbox(self, task: law.Task) -> str:
-        # venv_ml_tf sandbox but with scikit-learn and restrictet to tf 2.11.0
+        # venv_ml_tf sandbox but with scikit-learn and restricted to tf 2.11.0
         return dev_sandbox("bash::$HBW_BASE/sandboxes/venv_ml_plotting.sh")
-        # return dev_sandbox("bash::$CF_BASE/sandboxes/venv_ml_tf.sh")
 
     def datasets(self, config_inst: od.Config) -> set[od.Dataset]:
         return {config_inst.get_dataset(dataset_name) for dataset_name in self.dataset_names}

--- a/hbw/production/weights.py
+++ b/hbw/production/weights.py
@@ -114,16 +114,23 @@ normalized_pdf_weights = normalized_weight_factory(
     weight_producers={pdf_weights},
 )
 
+normalized_pu_weights = normalized_weight_factory(
+    producer_name="normalized_pu_weights",
+    weight_producers={pu_weight},
+)
+
 
 @producer(
     uses={
         normalization_weights, electron_weights, muon_weights, btag_weights,
-        normalized_btag_weights, event_weight,
+        normalized_btag_weights, normalized_pu_weights,
+        event_weight,
     },
     produces={
         "mc_weight",  # might be needed for ML
         normalization_weights, electron_weights, muon_weights,
-        normalized_btag_weights, event_weight,
+        normalized_btag_weights, normalized_pu_weights,
+        event_weight,
     },
     mc_only=True,
 )
@@ -144,6 +151,7 @@ def event_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     # normalize event weights using stats
     events = self[normalized_btag_weights](events, **kwargs)
+    events = self[normalized_pu_weights](events, **kwargs)
 
     if not self.dataset_inst.has_tag("skip_scale"):
         events = self[normalized_scale_weights](events, **kwargs)

--- a/hbw/scripts/hbwtasks.sh
+++ b/hbw/scripts/hbwtasks.sh
@@ -1,21 +1,30 @@
 #!/bin/sh
 # small script to source to quickly run tasks
 
-# versioning
-version="v1"
+# versioning and custom checksum (checksum only used for reduction, ml_training, datacards)
+version="prod1"
+checksum="prod1"
 
 # possible config choices: "c17", "l17"
 # NOTE: use "l17" for testing purposes
 config="c17"
 datasets="*"
 
-# NOTE: running this starts quite a lot of jobs, so only submit if everything is ready
+hbw_selection(){
+    law run cf.SelectEvents --version $version \
+	--config $config \
+	$@
+}
+
+#
+# Production tasks (will submit jobs and use cf.BundleRepo outputs based on the checksum)
+#
+
 hbw_reduction(){
-    law run cf.ReduceEventsWrapper --version $version --workers 50 \
+    law run cf.ReduceEventsWrapper --version $version --workers 20 \
 	--configs $config \
 	--shifts nominal \
 	--datasets $datasets \
-	--skip-datasets "qqHH*" \
 	--cf.ReduceEvents-workflow htcondor \
 	--cf.ReduceEvents-pilot \
 	--cf.ReduceEvents-no-poll \
@@ -23,29 +32,14 @@ hbw_reduction(){
 	--cf.ReduceEvents-retries 1 \
 	--cf.ReduceEvents-tasks-per-job 1 \
 	--cf.ReduceEvents-job-workers 1 \
+	--cf.BundleRepo-custom-checksum $checksum \
 	$@
 }
 
-hbw_cutflow(){
-    for steps in "resolved" "boosted"
-    do
-	law run cf.PlotCutflow --version $version --workers 4 \
-	    --config l17 \
-	    --selector-steps $steps \
-	    --shift nominal \
-	    --processes with_qcd \
-	    --process-settings unstack_all \
-	    --shape-norm True --yscale log --cms-label simpw \
-	    --remove-output 0,a,y --view-cmd imgcat \
-	    $@
-    done
-}
-
 ml_model="dense_default"
-ml_datasets="ml"
 
 hbw_ml_training(){
-    law run cf.MLTraining --version $version --workers 10 \
+    law run cf.MLTraining --version $version --workers 20 \
 	--configs $config \
 	--ml-model $ml_model \
 	--workflow htcondor \
@@ -58,97 +52,17 @@ hbw_ml_training(){
 	--cf.PrepareMLEvents-htcondor-memory 4000 \
 	--cf.PrepareMLEvents-max-runtime 3h \
 	--cf.PrepareMLEvents-pilot True \
+	--cf.MergeReducedEvents-workflow local \
+	--cf.MergeReductionStats-n-inputs -1 \
+	--cf.ReduceEvents-workflow htcondor \
+	--cf.ReduceEvents-pilot True \
+	--cf.BundleRepo-custom-checksum $checksum \
 	--retries 1 \
-	$@
-}
-
-hbw_ml_preparation(){
-    for i in {0..4}
-    do
-	law run cf.MergeMLEventsWrapper --version $version --workers 10 \
-	    --configs $config \
-	    --cf.MergeMLEvents-ml-model $ml_model \
-	    --cf.MergeMLEvents-fold $i \
-	    --datasets $ml_datasets \
-	    --skip-datasets "qqHH*,data*" \
-	    --cf.MergeMLEvents-workflow local \
-	    --cf.PrepareMLEvents-pilot True \
-	    --cf.PrepareMLEvents-workflow htcondor \
-	    --cf.PrepareMLEvents-parallel-jobs 4000 \
-	    --cf.PrepareMLEvents-retries 1 \
-	    --cf.PrepareMLEvents-tasks-per-job 1 \
-	    --cf.PrepareMLEvents-job-workers 1 \
-	    $@
-    done
-}
-
-processes="default"
-categories="resolved,boosted,incl"
-variables="mli_*"
-
-# NOTE: running this starts quite a lot of jobs, so only submit if everything is ready
-hbw_plot_variables(){
-    law run cf.PlotVariables1D --version $version --workers 50 \
-	--config $config \
-	--processes $processes \
-	--variables $variables \
-	--categories $categories \
-	--process-settings unstack_signal --shape-norm True --yscale log --cms-label simpw --skip-ratio True \
-	--workflow htcondor \
-	--pilot True \
-	--parallel-jobs 4000 \
-	--htcondor-share-software True \
-	--tasks-per-job 1 \
-	--job-workers 1 \
-	$@
-}
-
-ml_model="dense_default"
-ml_output_variables="mlscore.*"
-ml_categories="resolved,boosted,incl,ml_ggHH_kl_1_kt_1_sl_hbbhww,ml_tt,ml_st,ml_w_lnu,ml_dy_lep"
-
-hbw_plot_ml_nodes(){
-    law run cf.PlotVariables1D --version $version --workers 50 \
-	--config $config \
-	--ml-models $ml_model \
-	--processes $processes \
-	--variables $ml_output_variables \
-	--categories $ml_categories \
-	--process-settings unstack_signal --shape-norm True --yscale log --cms-label simpw --skip-ratio True \
-	--workflow htcondor \
-	--pilot True \
-	--retries 1 \
-    $@
-}
-
-hbw_control_plots_noData_much(){
-    law run cf.PlotVariables1D --version $version --workers 50 \
-	--config $config \
-	--producers features \
-	--processes much \
-	--process-settings scale_signal \
-	--variables "*" \
-	--categories "1mu,1mu__resolved,1mu__boosted" \
-	--yscale log --skip-ratio True --cms-label simpw \
-	--workflow htcondor \
-	$@
-}
-
-hbw_control_plots_much(){
-    law run cf.PlotVariables1D --version $version --workers 50 \
-	--config $config \
-	--producers features \
-	--processes dmuch \
-	--process-settings scale_signal \
-	--variables "*" \
-	--categories "1mu,1mu__resolved,1mu__boosted" \
-	--yscale log --cms-label pw \
-	--workflow htcondor \
 	$@
 }
 
 hbw_datacards(){
-    law run cf.CreateDatacards --version $version --workers 50 \
+    law run cf.CreateDatacards --version $version --workers 20 \
 	--config $config \
 	--ml-models $ml_model \
 	--pilot --workflow htcondor \
@@ -161,7 +75,79 @@ hbw_datacards(){
 	--cf.PrepareMLEvents-htcondor-gpus 0 \
 	--cf.PrepareMLEvents-htcondor-memory 4000 \
 	--cf.PrepareMLEvents-max-runtime 3h \
-	--cf.PrepareMLEvents-pilot True \
-	--cf.ReduceEvents-workflow htcondor
+	--cf.ReduceEvents-workflow htcondor \
+	--cf.ReduceEvents-pilot True \
+	--cf.BundleRepo-custom-checksum $checksum \
+	$@
+}
+
+#
+# Plotting tasks (no assumptions on workers, workflow etc.)
+#
+
+hbw_cutflow(){
+    for steps in "resolved" "boosted"
+    do
+	law run cf.PlotCutflow --version $version \
+	    --config l17 \
+	    --selector-steps $steps \
+	    --shift nominal \
+	    --processes with_qcd \
+	    --process-settings unstack_all \
+	    --shape-norm True --yscale log --cms-label simpw \
+	    --view-cmd imgcat \
+	    $@
+    done
+}
+
+processes="default"
+categories="resolved,boosted,incl"
+variables="mli_*"
+
+hbw_plot_variables(){
+    law run cf.PlotVariables1D --version $version \
+	--config $config \
+	--processes $processes \
+	--variables $variables \
+	--categories $categories \
+	--process-settings unstack_signal --shape-norm True --yscale log --cms-label simpw --skip-ratio True \
+	$@
+}
+
+ml_output_variables="mlscore.*"
+ml_categories="resolved,boosted,incl,ml_ggHH_kl_1_kt_1_sl_hbbhww,ml_tt,ml_st,ml_w_lnu,ml_dy_lep"
+
+hbw_plot_ml_nodes(){
+    law run cf.PlotVariables1D --version $version \
+	--config $config \
+	--ml-models $ml_model \
+	--processes $processes \
+	--variables $ml_output_variables \
+	--categories $ml_categories \
+	--process-settings unstack_signal --shape-norm True --yscale log --cms-label simpw --skip-ratio True \
+    $@
+}
+
+hbw_control_plots_noData_much(){
+    law run cf.PlotVariables1D --version $version \
+	--config $config \
+	--producers features \
+	--processes much \
+	--process-settings scale_signal \
+	--variables "*" \
+	--categories "1mu,1mu__resolved,1mu__boosted" \
+	--yscale log --skip-ratio True --cms-label simpw \
+	$@
+}
+
+hbw_control_plots_much(){
+    law run cf.PlotVariables1D --version $version \
+	--config $config \
+	--producers features \
+	--processes dmuch \
+	--process-settings scale_signal \
+	--variables "*" \
+	--categories "1mu,1mu__resolved,1mu__boosted" \
+	--yscale log --cms-label pw \
 	$@
 }

--- a/law.cfg
+++ b/law.cfg
@@ -35,9 +35,13 @@ skip_ensure_proxy: False
 
 chunked_io_chunk_size: 100000
 chunked_io_pool_size: 2
-##chunked_io_debug: True 
+chunked_io_debug: False
 
-time_task_array_functions: False
+# whether to log runtimes of array functions by default
+log_array_function_runtime: False
+
+# Tasks for which outputs will be checked for non-finite values before saving them to disk
+check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation, cf.UniteColumns
 
 [outputs]
 
@@ -68,20 +72,47 @@ lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirec
 # cf.MLTraining: wlcg
 # cf.MLEvaluation: wlcg
 
-# NOTE: the law.cfg can in theory be used to set defaults,
-# but this is currently not implemented
-[cf.ReduceEvents]
-no_poll: True
-workflow: htcondor
-dataset: tt_sl_powheg
+# To set defaults on a per-task basis
+# NOTE: this does override defaults defined in the config, but it does not overwrite parameters
+#       when the parameter has already been set e.g. by another task requiring this task
+
+# TODO: to share some outputs over multiple analyses
+# [luigi_cf.GetDatasetLFNs]
+
+# analysis: hbw.analysis.hbw_merged.hbw_merged
+
+
+# [luigi_cf.CalibrateEvents]
+
+# analysis: hbw.analysis.hbw_merged.hbw_merged
+
+
+[luigi_cf.ReduceEvents]
 pilot: True
 
-[cf.MLTraining]
+
+# TODO: it would be good if these parameters could be overwritten even when required from MLTraining
+[luigi_cf.PrepareMLEvents]
+
+htcondor-gpus: 0
+htcondor-memory: -1
+max-runtime: 4h
+
+
+[luigi_cf.MergeMLEvents]
+
+htcondor-gpus: 0
+htcondor-memory: -1
+max-runtime: 4h
+
+
+[luigi_cf.MLTraining]
+
 workflow: htcondor
 htcondor-gpus: 1
 htcondor-memory: 60000
 max-runtime: 72h
-pilot: True
+
 
 [job]
 
@@ -184,9 +215,3 @@ base: &::gsiftp_base
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 base: &::gsiftp_base
-
-
-# NOTE: we want to run the scheduler with multiple cores, but for some reason, this does not work
-[luigi_core]
-parallel_scheduling: False
-parallel_scheduling_processes: 2


### PR DESCRIPTION
This PR:

- includes e, mu and PU SFs into the overall event weight
- implements a tag to switch to custom signal samples
- includes Pileup in cutflow variables
- some cleanup in helper scripts