### PR TITLE
adding vbf signal output node, category and new ml variables + adding personal conveniences

### DIFF
--- a/MoveToAFS.py
+++ b/MoveToAFS.py
@@ -1,0 +1,129 @@
+!/usr/bin/python
+
+from datetime import datetime
+import sys, time, subprocess
+#from ROOT import *
+from multiprocessing import Pool, Value
+import random
+import shutil
+import glob
+import os
+import shutil
+import json
+
+debug = False
+
+# list with the control plots
+#'plot__proc_16_fabce60b2b__cat_incl__var_electron_eta.png', (before ml_inputs)
+
+plots = [
+'plot__proc_22_96f5201175__cat_incl__var_electron_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_electron_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_electron_pt.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_btagHbb.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_deepTagMD_HbbvsQCD.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_mass.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_msoftdrop.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_pt.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_tau1.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_tau2.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet1_tau21.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_btagHbb.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_deepTagMD_HbbvsQCD.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_mass.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_msoftdrop.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_pt.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_tau1.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_tau2.png',
+'plot__proc_22_96f5201175__cat_incl__var_fatjet2_tau21.png',
+#'plot__proc_22_96f5201175__cat_incl__var_jet1_btagDeepB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet1_btagDeepFlavB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet1_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet1_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet1_pt.png',
+#'plot__proc_22_96f5201175__cat_incl__var_jet2_btagDeepB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet2_btagDeepFlavB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet2_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet2_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet2_pt.png',
+#'plot__proc_22_96f5201175__cat_incl__var_jet3_btagDeepB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet3_btagDeepFlavB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet3_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet3_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet3_pt.png',
+#'plot__proc_22_96f5201175__cat_incl__var_jet4_btagDeepB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet4_btagDeepFlavB.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet4_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet4_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_jet4_pt.png',
+'plot__proc_22_96f5201175__cat_incl__var_muon_eta.png',
+'plot__proc_22_96f5201175__cat_incl__var_muon_phi.png',
+'plot__proc_22_96f5201175__cat_incl__var_muon_pt.png',
+'plot__proc_22_96f5201175__cat_incl__var_n_electron.png',
+'plot__proc_22_96f5201175__cat_incl__var_n_fatjet.png',
+'plot__proc_22_96f5201175__cat_incl__var_n_jet.png',
+'plot__proc_22_96f5201175__cat_incl__var_n_muon.png',
+]
+
+# String list for path_in (where the plots are created)
+
+strings = ['config_2017/', 'nominal/', 'calib__skip_jecunc/', 'sel__default/', 'prod__features/', 'datasets_38_3fc8d30155/', 'v1/']
+#config = 'config_2017'
+#shifts = 'nominal'
+#calibration = 'calib__skip_jecunc'
+#selector = 'sel__default'
+#producer = 'prod__features'
+#dataset = 'datasets_38_3fc8d30155'
+#version = 'v1'
+
+# ------------------------------------------------------------------------------
+
+def MoveToAFS():
+
+    path_in  = '/nfs/dust/cms/user/moelsjan/WorkingArea/DiHiggs/hh2bbww/data/hbw_store/analysis_hbw/cf.PlotVariables1D/'
+    path_out = '/afs/desy.de/user/m/moelsjan/public/controlplots/control_17.05./'
+
+    for string in strings:
+        path_in += string
+
+    #print "Start moving ... "
+    cmd  = 'cp'+' '
+    cmd += path_in
+    for plot in plots:
+
+        cmd1 = cmd
+        cmd1 += plot + ' ' + path_out
+
+        os.system(cmd1)
+
+        #for key2 in plots[plot1]:
+        #    cmd2  = cmd1
+        #    cmd2 += key2+' '
+        #    cmd2 += path_out
+        #    cmd2 += plots[plot1][key2]
+
+            #cmd_list = [cmd2]
+            #if 'FSR/SYS' in key1:
+            #    cmd_list = [cmd2.replace('PLACEHOLDER', h) for h in FSRsys]
+            #if 'JetCorrections' in key1:
+            #    cmd_list = [cmd2.replace(path_in, path_in2)]
+
+            #if debug:
+            #    print cmd_list
+
+            #for c in cmd_list:
+                #print_tmp = c.replace(tmp_nfs, '')
+                #print_cmd = print_tmp.replace(tmp_afs, '')
+                #print print_cmd
+                #os.system(c)
+
+
+# ------------------------------------------------------------------------------
+#
+
+if __name__ == "__main__":
+    MoveToAFS()

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -184,7 +184,7 @@ def add_config(
         "qcd_bctoe_pt170to250_pythia", "qcd_bctoe_pt250toInf_pythia",
         # TTV, VV -> ignore?; Higgs -> not used in Msc, but would be interesting
         # HH(bbtautau)
-        "hh_ggf_bbtautau_madgraph",
+        #"hh_ggf_bbtautau_madgraph",
     ]
 
     if cfg.has_tag("is_sl") and cfg.has_tag("is_nonresonant"):

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -37,7 +37,7 @@ def default_producers(cls, container, task_params):
 
     # per default, use the ml_inputs and event_weights
     # TODO: we might need two ml_inputs producers in the future (sl vs dl)
-    default_producers = ["ml_inputs", "event_weights"]
+    default_producers = ["ml_inputs"] #"event_weights"]
 
     # check if a ml_model has been set
     ml_model = task_params.get("mlmodel", None) or task_params.get("mlmodels", None)
@@ -148,6 +148,16 @@ def set_config_defaults_and_groups(config_inst):
         "default": ["n_jet", "n_muon", "n_electron", "ht", "m_bb", "deltaR_bb", "jet1_pt"],  # n_deepjet, ....
         "test": ["n_jet", "n_electron", "jet1_pt"],
         "cutflow": ["cf_jet1_pt", "cf_jet4_pt", "cf_n_jet", "cf_n_electron", "cf_n_muon"],  # cf_n_deepjet
+        "control": ["n_jet", "n_fatjet", "n_electron", "n_muon",
+        "jet1_pt", "jet1_eta", "jet1_phi", "jet1_btagDeepFlavB", #"jet1_btagDeepB", 
+        "jet2_pt", "jet2_eta", "jet2_phi", "jet2_btagDeepFlavB", #"jet2_btagDeepB", 
+        "jet3_pt", "jet3_eta", "jet3_phi", "jet3_btagDeepFlavB", #"jet3_btagDeepB", 
+        "jet4_pt", "jet4_eta", "jet4_phi", "jet4_btagDeepFlavB", #"jet4_btagDeepB", 
+        "fatjet1_pt", "fatjet1_eta", "fatjet1_phi", "fatjet1_btagHbb", "fatjet1_deepTagMD_HbbvsQCD", "fatjet1_mass", "fatjet1_msoftdrop",
+        "fatjet1_tau1", "fatjet1_tau2", "fatjet1_tau21",
+        "fatjet2_pt", "fatjet2_eta", "fatjet2_phi", "fatjet2_btagHbb", "fatjet2_deepTagMD_HbbvsQCD", "fatjet2_mass", "fatjet2_msoftdrop",
+        "fatjet2_tau1", "fatjet2_tau2", "fatjet2_tau21",
+        "electron_pt", "electron_eta", "electron_phi", "muon_pt", "muon_eta", "muon_phi"],
     }
 
     # shift groups for conveniently looping over certain shifts
@@ -181,6 +191,8 @@ def set_config_defaults_and_groups(config_inst):
             proc.name: {"unstack": True, "scale": 10000}
             for proc in config_inst.processes if "HH" in proc.name
         },
+        "control": {"ggHH_kl_0_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True}, "ggHH_kl_1_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+        "ggHH_kl_2p45_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True}, "ggHH_kl_5_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True}},
     }
     # when drawing DY as a line, use a different type of yellow
     config_inst.x.process_settings_groups["unstack_all"].update({"dy_lep": {"unstack": True, "color": "#e6d800"}})

--- a/hbw/config/ml_variables.py
+++ b/hbw/config/ml_variables.py
@@ -199,6 +199,25 @@ def add_ml_variables(config: od.Config) -> None:
         log_x=True,
         x_title=r"$S_{min}$",
     )
+    config.add_variable(
+        name="mli_vbf_deta",
+        expression="mli_vbf_deta",
+        binning=(50, 2, 9.5),
+        x_title=r"$\Delta\eta(vbfjet1,vbfjet2)$",
+    )
+    config.add_variable(
+        name="mli_vbf_invmass",
+        expression="mli_vbf_invmass",
+        binning=(50, 400, 4000),
+        unit="GeV",
+        x_title="invarint mass of two vbf jets",
+    )
+    config.add_variable(
+        name="mli_vbf_tag",
+        expression="mli_vbf_tag",
+        binning=(2, -0.5, 1.5),
+        x_title="existence of at least two vbf jets = 1, else 0",
+    )
 
     for obj in ["b1", "b2", "j1", "j2", "lep", "met"]:
         for var in ["pt", "eta"]:

--- a/hbw/config/styling.py
+++ b/hbw/config/styling.py
@@ -31,7 +31,8 @@ default_process_colors = {
     "ggHH_kl_1_kt_1_sl_hbbhww": "#000000",  # black
     "ggHH_kl_0_kt_1_sl_hbbhww": "#1b9e77",  # green2
     "ggHH_kl_2p45_kt_1_sl_hbbhww": "#d95f02",  # orange2
-    "ggHH_kl_5_kt_1_sl_hbbhww": "#e7298a",  # pink2
+    #"ggHH_kl_5_kt_1_sl_hbbhww": "#e7298a",  # pink2
+    "ggHH_kl_5_kt_1_sl_hbbhww": "#000080",  # navy
     "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww": "#e41a1c",  # red
     "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww": "#377eb8",  # blue
     "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww": "#4daf4a",  # green

--- a/hbw/ml/base.py
+++ b/hbw/ml/base.py
@@ -594,6 +594,9 @@ class MLClassifierBase(MLModel):
 
         logger.info(f"Evaluation of dataset {task.dataset}")
 
+        if len(events) == 0:
+            return events
+
         # determine truth label of the dataset (-1 if not used in training)
         ml_truth_label = -1
         if events_used_in_training:

--- a/hbw/ml/dense_classifier.py
+++ b/hbw/ml/dense_classifier.py
@@ -27,6 +27,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     processes = [
         "ggHH_kl_1_kt_1_sl_hbbhww",
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
         "tt",
         "st",
         "v_lep",
@@ -36,6 +37,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     ml_process_weights = {
         "ggHH_kl_1_kt_1_sl_hbbhww": 1,
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww": 1,
         "tt": 2,
         "st": 2,
         "v_lep": 2,
@@ -45,6 +47,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     dataset_names = {
         "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
         # TTbar
         "tt_sl_powheg",
         "tt_dl_powheg",
@@ -160,7 +163,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
             return list(requested_configs)
         else:
             # use config_2017 per default
-            return ["config_2017"]
+            return ["c17"]
 
     def training_calibrators(self, config_inst: od.Config, requested_calibrators: Sequence[str]) -> list[str]:
         # fix MLTraining Phase Space
@@ -168,7 +171,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     def training_selector(self, config_inst: od.Config, requested_selector: str) -> str:
         # fix MLTraining Phase Space
-        return "default"
+        return "sl"
 
     def training_producers(self, config_inst: od.Config, requested_producers: Sequence[str]) -> list[str]:
         # fix MLTraining Phase Space
@@ -177,9 +180,9 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
 cls_dict_test = {
     "epochs": 4,
-    "processes": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st", "v_lep"],
+    "processes": ["ggHH_kl_1_kt_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww", "tt", "st", "v_lep"],
     "dataset_names": {
-        "ggHH_kl_1_kt_1_sl_hbbhww_powheg", "tt_dl_powheg",
+        "ggHH_kl_1_kt_1_sl_hbbhww_powheg", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph", "tt_dl_powheg",
         "st_tchannel_t_powheg", "w_lnu_ht400To600_madgraph",
     },
 }

--- a/hbw/production/features.py
+++ b/hbw/production/features.py
@@ -45,12 +45,14 @@ def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
 
 @producer(
-    uses={"Bjet.pt", "Bjet.eta", "Bjet.phi", "Bjet.mass"},
+    #uses={"Bjet.pt", "Bjet.eta", "Bjet.phi", "Bjet.mass"},
+    uses={"Bjet.pt", "Bjet.eta", "Bjet.phi", "Bjet.mass", "HbbJet.msoftdrop"},
     produces={"m_bb", "deltaR_bb"},
 )
 def bb_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     m_bb = (events.Bjet[:, 0] + events.Bjet[:, 1]).mass
+    m_bb = ak.where(ak.num(events.HbbJet) > 0, events.HbbJet[:,0].msoftdrop, m_bb)
     events = set_ak_column_f32(events, "m_bb", m_bb)
 
     deltaR_bb = events.Bjet[:, 0].delta_r(events.Bjet[:, 1])
@@ -65,7 +67,8 @@ def bb_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
 @producer(
     uses={
-        prepare_objects, category_ids, event_weights,
+        prepare_objects, category_ids, 
+        event_weights,
         bb_features, jj_features,
         "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta",
         "Jet.pt", "Jet.eta", "Jet.btagDeepFlavB",
@@ -75,7 +78,8 @@ def bb_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         "HbbJet.pt",
     },
     produces={
-        category_ids, event_weights,
+        category_ids, 
+        event_weights,
         bb_features, jj_features,
         "ht", "n_jet", "n_electron", "n_muon", "n_deepjet", "n_fatjet", "n_hbbjet", "FatJet.tau21",
     },

--- a/hbw/selection/categories.py
+++ b/hbw/selection/categories.py
@@ -71,7 +71,7 @@ def catid_2b(self: Selector, events: ak.Array, **kwargs) -> ak.Array:
 
 
 # TODO: not hard-coded -> use config?
-ml_processes = ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st", "w_lnu", "dy_lep", "v_lep"]
+ml_processes = ["ggHH_kl_1_kt_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww", "tt", "st", "w_lnu", "dy_lep", "v_lep"]
 for proc in ml_processes:
     @selector(
         uses=set(f"mlscore.{proc1}" for proc1 in ml_processes),


### PR DESCRIPTION
I've added some conveniences in the first two commits, so I don't have to change them myself every time I pull from the master. These conveniences include a hard coded script, which moves my control plots to the afs, so I can upload them to my CERN website, a colour styling choice for a certain signal sample, adding a control variable group and process-settings group and comment the HH->bbtautau signal sample out.

The third commit changes the definition of the m_bb-variable for the boosted HbbJets, so I can use this variable in the inference model.

The fourth commit adds the vbf signal output node to the machine learning model, adds the vbf category to the ml categorization and I've created three new ml-variables, that target the vbf channel. These variables are the delta eta between two Jets from the VBFJet-Collection from the selection, the invariant mass of these jets and a simple tag that checks if there are at least two VBFJets for the event or not.