### PR TITLE
adding vbf signal output node, category and new ml variables + adding control plots group

### DIFF
--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -168,16 +168,18 @@ def set_config_defaults_and_groups(config_inst):
             "ll_pt", "bb_pt", "E_miss", "delta_Phi", "MT", "min_dr_lljj",
             "m_lljjMET", "channel_id", "n_bjet", "wp_score", "charge", "m_ll_check",
         ],
-        "control": ["n_jet", "n_fatjet", "n_electron", "n_muon",
-        "jet1_pt", "jet1_eta", "jet1_phi", "jet1_btagDeepFlavB",   # "jet1_btagDeepB",
-        "jet2_pt", "jet2_eta", "jet2_phi", "jet2_btagDeepFlavB",   # "jet2_btagDeepB",
-        "jet3_pt", "jet3_eta", "jet3_phi", "jet3_btagDeepFlavB",   # "jet3_btagDeepB",
-        "jet4_pt", "jet4_eta", "jet4_phi", "jet4_btagDeepFlavB",   # "jet4_btagDeepB",
-        "fatjet1_pt", "fatjet1_eta", "fatjet1_phi", "fatjet1_btagHbb", "fatjet1_deepTagMD_HbbvsQCD",
-        "fatjet1_mass", "fatjet1_msoftdrop", "fatjet1_tau1", "fatjet1_tau2", "fatjet1_tau21",
-        "fatjet2_pt", "fatjet2_eta", "fatjet2_phi", "fatjet2_btagHbb", "fatjet2_deepTagMD_HbbvsQCD",
-        "fatjet2_mass", "fatjet2_msoftdrop", "fatjet2_tau1", "fatjet2_tau2", "fatjet2_tau21",
-        "electron_pt", "electron_eta", "electron_phi", "muon_pt", "muon_eta", "muon_phi"],
+        "control": [
+            "n_jet", "n_fatjet", "n_electron", "n_muon",
+            "jet1_pt", "jet1_eta", "jet1_phi", "jet1_btagDeepFlavB",   # "jet1_btagDeepB",
+            "jet2_pt", "jet2_eta", "jet2_phi", "jet2_btagDeepFlavB",   # "jet2_btagDeepB",
+            "jet3_pt", "jet3_eta", "jet3_phi", "jet3_btagDeepFlavB",   # "jet3_btagDeepB",
+            "jet4_pt", "jet4_eta", "jet4_phi", "jet4_btagDeepFlavB",   # "jet4_btagDeepB",
+            "fatjet1_pt", "fatjet1_eta", "fatjet1_phi", "fatjet1_btagHbb", "fatjet1_deepTagMD_HbbvsQCD",
+            "fatjet1_mass", "fatjet1_msoftdrop", "fatjet1_tau1", "fatjet1_tau2", "fatjet1_tau21",
+            "fatjet2_pt", "fatjet2_eta", "fatjet2_phi", "fatjet2_btagHbb", "fatjet2_deepTagMD_HbbvsQCD",
+            "fatjet2_mass", "fatjet2_msoftdrop", "fatjet2_tau1", "fatjet2_tau2", "fatjet2_tau21",
+            "electron_pt", "electron_eta", "electron_phi", "muon_pt", "muon_eta", "muon_phi",
+        ],
     }
 
     # shift groups for conveniently looping over certain shifts
@@ -221,10 +223,12 @@ def set_config_defaults_and_groups(config_inst):
         "dileptest": {
             "ggHH_kl_1_kt_1_dl_hbbhww": {"scale": 10000, "unstack": True},
         },
-        "control": {"ggHH_kl_0_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
-        "ggHH_kl_1_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
-        "ggHH_kl_2p45_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
-        "ggHH_kl_5_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True}},
+        "control": {
+            "ggHH_kl_0_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+            "ggHH_kl_1_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+            "ggHH_kl_2p45_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+            "ggHH_kl_5_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+        },
     }
     # when drawing DY as a line, use a different type of yellow
     config_inst.x.process_settings_groups["unstack_all"].update({"dy_lep": {"unstack": True, "color": "#e6d800"}})

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -168,6 +168,16 @@ def set_config_defaults_and_groups(config_inst):
             "ll_pt", "bb_pt", "E_miss", "delta_Phi", "MT", "min_dr_lljj",
             "m_lljjMET", "channel_id", "n_bjet", "wp_score", "charge", "m_ll_check",
         ],
+        "control": ["n_jet", "n_fatjet", "n_electron", "n_muon",
+        "jet1_pt", "jet1_eta", "jet1_phi", "jet1_btagDeepFlavB",   # "jet1_btagDeepB",
+        "jet2_pt", "jet2_eta", "jet2_phi", "jet2_btagDeepFlavB",   # "jet2_btagDeepB",
+        "jet3_pt", "jet3_eta", "jet3_phi", "jet3_btagDeepFlavB",   # "jet3_btagDeepB",
+        "jet4_pt", "jet4_eta", "jet4_phi", "jet4_btagDeepFlavB",   # "jet4_btagDeepB",
+        "fatjet1_pt", "fatjet1_eta", "fatjet1_phi", "fatjet1_btagHbb", "fatjet1_deepTagMD_HbbvsQCD",
+        "fatjet1_mass", "fatjet1_msoftdrop", "fatjet1_tau1", "fatjet1_tau2", "fatjet1_tau21",
+        "fatjet2_pt", "fatjet2_eta", "fatjet2_phi", "fatjet2_btagHbb", "fatjet2_deepTagMD_HbbvsQCD",
+        "fatjet2_mass", "fatjet2_msoftdrop", "fatjet2_tau1", "fatjet2_tau2", "fatjet2_tau21",
+        "electron_pt", "electron_eta", "electron_phi", "muon_pt", "muon_eta", "muon_phi"],
     }
 
     # shift groups for conveniently looping over certain shifts
@@ -211,6 +221,10 @@ def set_config_defaults_and_groups(config_inst):
         "dileptest": {
             "ggHH_kl_1_kt_1_dl_hbbhww": {"scale": 10000, "unstack": True},
         },
+        "control": {"ggHH_kl_0_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+        "ggHH_kl_1_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+        "ggHH_kl_2p45_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True},
+        "ggHH_kl_5_kt_1_sl_hbbhww": {"scale": 90000, "unstack": True}},
     }
     # when drawing DY as a line, use a different type of yellow
     config_inst.x.process_settings_groups["unstack_all"].update({"dy_lep": {"unstack": True, "color": "#e6d800"}})

--- a/hbw/config/ml_variables.py
+++ b/hbw/config/ml_variables.py
@@ -201,6 +201,25 @@ def add_ml_variables(config: od.Config) -> None:
         log_x=True,
         x_title=r"$S_{min}$",
     )
+    config.add_variable(
+        name="mli_vbf_deta",
+        expression="mli_vbf_deta",
+        binning=(50, 2, 9.5),
+        x_title=r"$\Delta\eta(vbfjet1,vbfjet2)$",
+    )
+    config.add_variable(
+        name="mli_vbf_invmass",
+        expression="mli_vbf_invmass",
+        binning=(50, 400, 4000),
+        unit="GeV",
+        x_title="invarint mass of two vbf jets",
+    )
+    config.add_variable(
+        name="mli_vbf_tag",
+        expression="mli_vbf_tag",
+        binning=(2, -0.5, 1.5),
+        x_title="existence of at least two vbf jets = 1, else 0",
+    )
 
     for obj in ["b1", "b2", "j1", "j2", "lep", "met"]:
         for var in ["pt", "eta"]:

--- a/hbw/config/styling.py
+++ b/hbw/config/styling.py
@@ -31,7 +31,8 @@ default_process_colors = {
     "ggHH_kl_1_kt_1_sl_hbbhww": "#000000",  # black
     "ggHH_kl_0_kt_1_sl_hbbhww": "#1b9e77",  # green2
     "ggHH_kl_2p45_kt_1_sl_hbbhww": "#d95f02",  # orange2
-    "ggHH_kl_5_kt_1_sl_hbbhww": "#e7298a",  # pink2
+    # "ggHH_kl_5_kt_1_sl_hbbhww": "#e7298a",  # pink2
+    "ggHH_kl_5_kt_1_sl_hbbhww": "#000080",  # navy
     "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww": "#e41a1c",  # red
     "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww": "#377eb8",  # blue
     "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww": "#4daf4a",  # green

--- a/hbw/config/variables.py
+++ b/hbw/config/variables.py
@@ -92,6 +92,12 @@ def add_feature_variables(config: od.Config) -> None:
         x_title=r"$m_{bb}$",
     )
     config.add_variable(
+        name="m_bb_combined",
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"$m_{bb}$ combined",
+    )
+    config.add_variable(
         name="bb_pt",
         binning=(40, 0., 350),
         x_title=r"$p_T^{bb}$",

--- a/hbw/ml/base.py
+++ b/hbw/ml/base.py
@@ -232,6 +232,9 @@ class MLClassifierBase(MLModel):
             t0 = time.perf_counter()
             for fn in proc_inst.x.filenames:
                 events = ak.from_parquet(fn)
+                if len(events) == 0:
+                    logger.warning("File {fn} of process {proc_inst.name} is empty and will be skipped")
+                    continue
 
                 # check that all relevant input features are present
                 if not set(self.input_features).issubset(set(events.fields)):
@@ -592,9 +595,6 @@ class MLClassifierBase(MLModel):
             return events
 
         logger.info(f"Evaluation of dataset {task.dataset}")
-
-        if len(events) == 0:
-            return events
 
         # determine truth label of the dataset (-1 if not used in training)
         ml_truth_label = -1

--- a/hbw/ml/base.py
+++ b/hbw/ml/base.py
@@ -593,6 +593,9 @@ class MLClassifierBase(MLModel):
 
         logger.info(f"Evaluation of dataset {task.dataset}")
 
+        if len(events) == 0:
+            return events
+
         # determine truth label of the dataset (-1 if not used in training)
         ml_truth_label = -1
         if events_used_in_training:

--- a/hbw/ml/dense_classifier.py
+++ b/hbw/ml/dense_classifier.py
@@ -27,6 +27,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     processes = [
         "ggHH_kl_1_kt_1_sl_hbbhww",
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
         "tt",
         "st",
         "v_lep",
@@ -36,6 +37,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     ml_process_weights = {
         "ggHH_kl_1_kt_1_sl_hbbhww": 1,
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww": 1,
         "tt": 2,
         "st": 2,
         "v_lep": 2,
@@ -45,6 +47,7 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
     dataset_names = {
         "ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+        "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
         # TTbar
         "tt_sl_powheg",
         "tt_dl_powheg",
@@ -177,9 +180,9 @@ class DenseClassifier(ModelFitMixin, DenseModelMixin, MLClassifierBase):
 
 cls_dict_test = {
     "epochs": 4,
-    "processes": ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st", "v_lep"],
+    "processes": ["ggHH_kl_1_kt_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww", "tt", "st", "v_lep"],
     "dataset_names": {
-        "ggHH_kl_1_kt_1_sl_hbbhww_powheg", "tt_dl_powheg",
+        "ggHH_kl_1_kt_1_sl_hbbhww_powheg", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph", "tt_dl_powheg",
         "st_tchannel_t_powheg", "w_lnu_ht400To600_madgraph",
     },
 }

--- a/hbw/production/features.py
+++ b/hbw/production/features.py
@@ -50,17 +50,20 @@ def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     uses={
         "HbbJet.msoftdrop",
     } | four_vec("Jet"),
-    produces={"m_bb", "bb_pt", "deltaR_bb"},
+    produces={"m_bb", "bb_pt", "deltaR_bb", "m_bb_combined"},
 )
 def bb_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     # create bb features
     bb = (events.Bjet[:, 0] + events.Bjet[:, 1])
-    m_bb = (events.Bjet[:, 0] + events.Bjet[:, 1]).mass
-    m_bb = ak.where(ak.num(events.HbbJet) > 0, events.HbbJet[:, 0].msoftdrop, m_bb)
-    deltaR_bb = events.Bjet[:, 0].delta_r(events.Bjet[:, 1])
-    events = set_ak_column_f32(events, "m_bb", m_bb)
+    events = set_ak_column_f32(events, "m_bb", bb.mass)
     events = set_ak_column_f32(events, "bb_pt", bb.pt)
+
+    deltaR_bb = events.Bjet[:, 0].delta_r(events.Bjet[:, 1])
     events = set_ak_column_f32(events, "deltaR_bb", deltaR_bb)
+
+    # combination of resolved and boosted bb mass
+    m_bb_combined = ak.where(ak.num(events.HbbJet) > 0, events.HbbJet[:, 0].msoftdrop, bb.mass)
+    events = set_ak_column_f32(events, "m_bb_combined", m_bb_combined)
 
     # fill none values
     for col in self.produces:

--- a/hbw/production/ml_inputs.py
+++ b/hbw/production/ml_inputs.py
@@ -30,7 +30,7 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
         "HbbJet.msoftdrop", "HbbJet.deepTagMD_HbbvsQCD",
         "Jet.btagDeepFlavB", "Bjet.btagDeepFlavB", "Lightjet.btagDeepFlavB",
     } | four_vec(
-        {"Electron", "Muon", "MET", "Jet", "Bjet", "Lightjet", "HbbJet"},
+        {"Electron", "Muon", "MET", "Jet", "Bjet", "Lightjet", "HbbJet", "VBFJet"},
     ),
     produces={
         category_ids, event_weights,
@@ -53,6 +53,7 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column(events, "Bjet", ak.pad_none(events.Bjet, 2))
     # events = set_ak_column(events, "FatJet", ak.pad_none(events.FatJet, 1))
     events = set_ak_column(events, "HbbJet", ak.pad_none(events.HbbJet, 1))
+    events = set_ak_column_f32(events, "VBFJet", ak.pad_none(events.VBFJet, 2))
 
     # low-level features
     # TODO: this could be more generalized
@@ -76,6 +77,13 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     jet_pairs = ak.combinations(events.Jet, 2)
     dr = jet_pairs[:, :, "0"].delta_r(jet_pairs[:, :, "1"])
     events = set_ak_column_f32(events, "mindr_jj", ak.min(dr, axis=1))
+
+    # vbf jet pair features
+
+    events = set_ak_column_f32(events, "mli_vbf_deta", abs(events.VBFJet[:, 0].eta - events.VBFJet[:, 1].eta))
+    events = set_ak_column_f32(events, "mli_vbf_invmass", (events.VBFJet[:, 0] + events.VBFJet[:, 1]).mass)
+    vbf_tag = ak.sum(events.VBFJet.pt > 0, axis=1) >= 2
+    events = set_ak_column_f32(events, "mli_vbf_tag", vbf_tag)
 
     # bjets in general
     wp_med = self.config_inst.x.btag_working_points.deepjet.medium
@@ -159,6 +167,7 @@ def ml_inputs_init(self: Producer) -> None:
         "mli_dphi_lnu", "mli_mlnu", "mli_mjjlnu", "mli_mjjl", "mli_dphi_bb_jjlnu", "mli_dr_bb_jjlnu",
         "mli_dphi_bb_jjl", "mli_dr_bb_jjl", "mli_dphi_bb_nu", "mli_dphi_jj_nu", "mli_dr_bb_l", "mli_dr_jj_l",
         "mli_mbbjjlnu", "mli_mbbjjl", "mli_s_min",
+        "mli_vbf_deta", "mli_vbf_invmass", "mli_vbf_tag",
     } | set(
         f"mli_{obj}_{var}"
         for obj in ["b1", "b2", "j1", "j2", "lep", "met"]

--- a/hbw/production/ml_inputs.py
+++ b/hbw/production/ml_inputs.py
@@ -53,7 +53,7 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column(events, "Bjet", ak.pad_none(events.Bjet, 2))
     # events = set_ak_column(events, "FatJet", ak.pad_none(events.FatJet, 1))
     events = set_ak_column(events, "HbbJet", ak.pad_none(events.HbbJet, 1))
-    events = set_ak_column_f32(events, "VBFJet", ak.pad_none(events.VBFJet, 2))
+    events = set_ak_column(events, "VBFJet", ak.pad_none(events.VBFJet, 2))
 
     # low-level features
     # TODO: this could be more generalized
@@ -79,7 +79,6 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column_f32(events, "mindr_jj", ak.min(dr, axis=1))
 
     # vbf jet pair features
-
     events = set_ak_column_f32(events, "mli_vbf_deta", abs(events.VBFJet[:, 0].eta - events.VBFJet[:, 1].eta))
     events = set_ak_column_f32(events, "mli_vbf_invmass", (events.VBFJet[:, 0] + events.VBFJet[:, 1]).mass)
     vbf_tag = ak.sum(events.VBFJet.pt > 0, axis=1) >= 2

--- a/hbw/selection/categories.py
+++ b/hbw/selection/categories.py
@@ -135,8 +135,8 @@ def catid_2b(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, a
     return events, mask
 
 
-# TODO: ml_processes not hard-coded -> use config?
-ml_processes = ["ggHH_kl_1_kt_1_sl_hbbhww", "tt", "st", "w_lnu", "dy_lep", "v_lep"]
+# TODO: not hard-coded -> use config?
+ml_processes = ["ggHH_kl_1_kt_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww", "tt", "st", "w_lnu", "dy_lep", "v_lep"]
 for proc in ml_processes:
     @categorizer(
         uses=set(f"mlscore.{proc1}" for proc1 in ml_processes),


### PR DESCRIPTION
I've added a personal colour styling choice for a certain signal sample, a control variable group and process-setting group and commented the HH -> bbtautau signal sample out in the first commit.

In the second commit I changed the definition of the m_bb variable for the boosted HbbJets, so I can use this variable in the inference model.

The third commit adds the vbf signal output node to the machine learning model, adds the vbf category to the ml categorization and I've created three new ml-variables, that target the vbf channel. These variables are the delta eta between two Jets from the VBFJet-Collection from the selection, the invariant mass of these jets and a simple tag that checks if there are at least two VBFJets for the event or not.