### PR TITLE
add some custom base and inspection task

### DIFF
--- a/hbw/tasks/base.py
+++ b/hbw/tasks/base.py
@@ -4,9 +4,90 @@
 Custom base tasks.
 """
 
-from columnflow.tasks.framework.base import BaseTask
+
+import law
+
+from columnflow.tasks.framework.base import Requirements, BaseTask
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
+)
+from columnflow.tasks.reduction import MergeReducedEventsUser, MergeReducedEvents
+from columnflow.tasks.production import ProduceColumns
+from columnflow.tasks.ml import MLEvaluation
+from columnflow.util import dev_sandbox, maybe_import
+
+ak = maybe_import("awkward")
 
 
 class HBWTask(BaseTask):
 
     task_namespace = "hbw"
+
+
+class ColumnsBaseTask(
+    HBWTask,
+    MLModelsMixin,
+    ProducersMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    MergeReducedEventsUser,
+    law.LocalWorkflow,
+):
+    """
+    Bask task to handle columns after Reduction, Production and MLEvaluation.
+    An exemplary implementation of how to handle the inputs in a run method can be
+    found in columnflow/tasks/union.py
+    """
+
+    exclude_index = True
+
+    # upstream requirements
+    reqs = Requirements(
+        MergeReducedEventsUser.reqs,
+        MergeReducedEvents=MergeReducedEvents,
+        ProduceColumns=ProduceColumns,
+        MLEvaluation=MLEvaluation,
+    )
+
+    # sandbox = dev_sandbox("bash::$HBW_BASE/sandboxes/venv_ml_plotting.sh")
+    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        # require the full merge forest
+        reqs["events"] = self.reqs.MergeReducedEvents.req(self, tree_index=-1)
+
+        if not self.pilot:
+            if self.producers:
+                reqs["producers"] = [
+                    self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                    for producer_inst in self.producer_insts
+                    if producer_inst.produced_columns
+                ]
+            if self.ml_models:
+                reqs["ml"] = [
+                    self.reqs.MLEvaluation.req(self, ml_model=m)
+                    for m in self.ml_models
+                ]
+
+        return reqs
+
+    def requires(self):
+        reqs = {
+            "events": self.reqs.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+        }
+
+        if self.producers:
+            reqs["producers"] = [
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
+            ]
+        if self.ml_models:
+            reqs["ml"] = [
+                self.reqs.MLEvaluation.req(self, ml_model=m)
+                for m in self.ml_models
+            ]
+
+        return reqs

--- a/hbw/tasks/inspection.py
+++ b/hbw/tasks/inspection.py
@@ -1,0 +1,121 @@
+# coding: utf-8
+
+"""
+Custom tasks for inspecting the configuration or certain task outputs.
+"""
+
+import law
+import luigi
+
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
+)
+from columnflow.tasks.reduction import MergeReducedEventsUser
+from columnflow.util import maybe_import
+from columnflow.columnar_util import get_ak_routes, update_ak_array
+
+from hbw.tasks.base import HBWTask, ColumnsBaseTask
+
+ak = maybe_import("awkward")
+
+
+class CheckConfig(
+    HBWTask,
+    MLModelsMixin,
+    ProducersMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    MergeReducedEventsUser,
+):
+    """
+    Task that inherits from relevant mixins to build the config inst based on CSP+ML init functions.
+    It only prints some informations from the config inst.
+    Does not require anything, does not output anything.
+    """
+
+    debugger = luigi.BoolParameter(
+        default=False,
+        description="Whether to start a ipython debugger session or not; default: True",
+    )
+
+    def requires(self):
+        return {}
+
+    def output(self):
+        return {"always_incomplete_dummy": self.target("dummy.txt")}
+
+    def run(self):
+        config = self.config_inst
+        dataset = self.dataset_inst
+        variables = config.variables
+        all_cats = [cat for cat, _, _ in config.walk_categories()]
+        leaf_cats = config.get_leaf_categories()
+        processes = [proc for proc, _, _ in config.walk_processes()]  # noqa
+
+        self.publish_message(
+            f"\nLooking at config '{config.name}' with dataset '{dataset.name}' and "
+            f"shift '{self.shift}' after running inits of calibrators "
+            f"{self.calibrators}, selector '{self.selector}', producer "
+            f"{self.producers}, and ml models {self.ml_models} \n",
+        )
+        self.publish_message(
+            f"{'=' * 10} Categories ({len(all_cats)}):\n{[cat.name for cat in all_cats]} \n\n"
+            f"{'=' * 10} Leaf Categories ({len(leaf_cats)}):\n{[cat.name for cat in leaf_cats]} \n\n"
+            f"{'=' * 10} Variables ({len(variables)}):\n{variables.names()} \n\n",
+        )
+        if self.debugger:
+            self.publish_message("starting debugger ....")
+            from hbw.util import debugger
+            debugger()
+
+
+class CheckColumns(
+    ColumnsBaseTask,
+    law.LocalWorkflow,
+):
+    """
+    Task to inspect columns after Reduction, Production and MLEvaluation.
+    """
+
+    debugger = luigi.BoolParameter(
+        default=False,
+        description="Whether to start a ipython debugger session or not; default: True",
+    )
+
+    def output(self):
+        return {"always_incomplete_dummy": self.target("dummy.txt")}
+
+    def run(self):
+        import awkward as ak
+        inputs = self.input()
+
+        config = self.config_inst
+        dataset = self.dataset_inst
+
+        self.publish_message(
+            f"\nLooking at columns from reduction, producers {self.producers}, and ml models "
+            f"{self.ml_models} using config '{config.name}' with dataset '{dataset.name}' and "
+            f"shift '{self.shift}', calibrators {self.calibrators}, and selector '{self.selector}'\n",
+        )
+
+        files = {"events": [inputs["events"]["collection"][0]["events"]][0]}
+        for i, producer in enumerate(self.producers):
+            files[producer] = inputs["producers"][i]["columns"]
+        for i, ml_model in enumerate(self.ml_models):
+            files[ml_model] = inputs["ml"][i]["mlcolumns"]
+
+        # open each file and check, which columns are present
+        # NOTE: we could use the Chunked Reader here aswell, but since we do not do any data processing,
+        #       it should be fine to shortly load the complete files into memory
+        for key, fname in files.items():
+            columns = ak.from_parquet(fname.path)
+            fields = [route.string_column for route in get_ak_routes(columns)]
+            self.publish_message(f"{'=' * 10} {key} fields:\n{fields} \n")
+
+        if self.debugger:
+            # when starting a debugger session, combine all columns into one ak.Array
+            events = ak.from_parquet(files["events"])
+            events = update_ak_array(events, *[ak.from_parquet(fname) for fname in files.values()])
+            self.publish_message("starting debugger ....")
+            from hbw.util import debugger
+            debugger()

--- a/law.cfg
+++ b/law.cfg
@@ -8,7 +8,7 @@ inherit: $CF_BASE/law.cfg
 
 columnflow.tasks.cms.external
 columnflow.tasks.cms.inference
-hbw.tasks.{ml,inference,wrapper}
+hbw.tasks.{inspection,ml,inference,wrapper}
 
 
 


### PR DESCRIPTION
Often, it is rather tedious/difficult to inspect the output of some task or the status of the config inst at a certain point of the analysis workflow. To simplify this, three tasks are added with this PR:

- `hbw.ColumnsBaseTask` provides a base implementation on how to require columns from reduction, production + ml evaluation combined. It's only a base task, so it cannot be run, but should be inherited of by other tasks.
- `hbw.CheckColumns` provides a simple implementation of reading these outputs and checking, which columns are present in each file
- `hbw.CheckConfig` only loads the config inst after all the CSP+ML inits have been run and prints some infos. It requires nothing and produces nothing

All three tasks own the typical parameters (selector, producers, ml_models, dataset, ...) and should also resolve defaults+groups as usual.
The hbw.Check* tasks also provide the `--debugger` parameter, which starts a ipython session at the end of the task.