### PR TITLE
Feature/inference updates

### DIFF
--- a/hbw/config/categories.py
+++ b/hbw/config/categories.py
@@ -80,6 +80,9 @@ def kwargs_fn(root_cats):
     kwargs = {
         "id": sum([c.id for c in root_cats.values()]),
         "label": ", ".join([c.name for c in root_cats.values()]),
+        "aux": {
+            "root_cats": {key: value.name for key, value in root_cats.items()},
+        },
     }
     return kwargs
 

--- a/hbw/inference/base.py
+++ b/hbw/inference/base.py
@@ -226,3 +226,34 @@ class HBWInferenceModelBase(InferenceModel):
                 self.add_parameter_to_group(shape_uncertainty, "theory")
             else:
                 self.add_parameter_to_group(shape_uncertainty, "experiment")
+
+
+class HBWNoMLInferenceModel(HBWInferenceModelBase):
+    def add_inference_categories(self: InferenceModel):
+        """
+        This function creates categories for the inference model
+        """
+
+        lepton_channels = self.config_inst.x.lepton_channels
+
+        for lep in lepton_channels:
+            cat_name = f"cat_{lep}"
+            if cat_name not in self.channels:
+                continue
+
+            cat_kwargs = {
+                "config_category": f"{lep}",
+                "config_variable": "mli_mbb",
+                "mc_stats": self.mc_stats,
+            }
+            if self.skip_data:
+                cat_kwargs["data_from_processes"] = self.processes
+            else:
+                cat_kwargs["config_data_datasets"] = const.data_datasets[lep]
+
+            self.add_category(cat_name, **cat_kwargs)
+
+            # get the inference category to do some customization
+            cat = self.get_category(cat_name)
+            # variables that are plotting via hbw.InferencePlots for this category
+            cat.plot_variables = ["jet1_pt"]

--- a/hbw/inference/base.py
+++ b/hbw/inference/base.py
@@ -8,8 +8,7 @@ import law
 import order as od
 
 from columnflow.inference import InferenceModel, ParameterType, ParameterTransformation
-from columnflow.ml import MLModel
-from columnflow.util import maybe_import
+from columnflow.util import maybe_import, DotDict
 from columnflow.config_util import get_datasets_from_process
 
 import hbw.inference.constants as const  # noqa
@@ -30,16 +29,17 @@ class HBWInferenceModelBase(InferenceModel):
     # Model attributes, can be changed via `cls.derive`
     #
 
-    # default ml model
-    ml_model_name = "dense_default"
+    # default ml model, used for resolving defaults
+    ml_model_name: str = "dense_default"
 
     # list of all processes/channels/systematics to include in the datacards
-    processes = []
-    channels = []
-    systematics = []
+    processes: list = []
+    channels: list = []
+    systematics: list = []
 
-    mc_stats = True
-    skip_data = True
+    # customization of channels
+    mc_stats: bool = True
+    skip_data: bool = True
 
     def __init__(self, config_inst: od.Config, *args, **kwargs):
         super().__init__(config_inst)
@@ -47,6 +47,7 @@ class HBWInferenceModelBase(InferenceModel):
         self.add_inference_categories()
         self.add_inference_processes()
         self.add_inference_parameters()
+        # self.print_model()
 
         #
         # post-processing
@@ -54,40 +55,70 @@ class HBWInferenceModelBase(InferenceModel):
 
         self.cleanup()
 
+    def print_model(self):
+        """ Helper to print categories, processes and parameters of the InferenceModel """
+        for cat in self.categories:
+            print(f"{'=' * 20} {cat.name}")
+            print(f"Variable {cat.config_variable} \nCategory {cat.config_category}")
+            print(f"Processes {[p.name for p in cat.processes]}")
+            print(f"Parameters {set().union(*[[param.name for param in proc.parameters] for proc in cat.processes])}")
+
+    def cat_name(self: InferenceModel, config_cat_inst: od.Category):
+        """ Function to determine inference category name from config category """
+        root_cats = config_cat_inst.x.root_cats
+        return "cat_" + "_".join(root_cats.values())
+
+    def config_variable(self: InferenceModel, config_cat_inst: od.Config):
+        """ Function to determine inference variable name from config category """
+        root_cats = config_cat_inst.x.root_cats
+        if dnn_cat := root_cats.get("dnn"):
+            dnn_proc = dnn_cat.replace("ml_", "")
+            return f"mlscore.{dnn_proc}_manybins"
+        else:
+            return "mli_mbb"
+
+    def customize_category(self: InferenceModel, cat_inst: DotDict, config_cat_inst: od.Config):
+        """ Function to allow customizing the inference category """
+        root_cats = config_cat_inst.x.root_cats
+        variables = ["jet1_pt"]
+        if dnn_cat := root_cats.get("dnn"):
+            dnn_proc = dnn_cat.replace("ml_", "")
+            variables.append(f"mlscore.{dnn_proc}")
+        cat_inst.variables_to_plot = variables
+
     def add_inference_categories(self: InferenceModel):
         """
         This function creates categories for the inference model
         """
 
-        # get processes used in MLTraining
-        ml_model_inst = MLModel.get_cls(self.ml_model_name)(self.config_inst)
-        ml_model_processes = ml_model_inst.processes
+        # get the MLModel inst
+        # ml_model_inst = MLModel.get_cls(self.ml_model_name)(self.config_inst)
 
-        lepton_channels = self.config_inst.x.lepton_channels
+        for config_category in self.config_categories:
+            cat_inst = self.config_inst.get_category(config_category)
+            root_cats = cat_inst.x.root_cats
+            lep_channel = root_cats.get("lep")
+            if lep_channel not in self.config_inst.x.lepton_channels:
+                raise Exception(
+                    "Each inference category needs to be categorized based on number of leptons; "
+                    f"Options: {self.config_inst.x.lepton_channels}",
+                )
 
-        for proc in ml_model_processes:
-            for lep in lepton_channels:
-                cat_name = f"cat_{lep}_{proc}"
-                if cat_name not in self.channels:
-                    continue
+            cat_name = self.cat_name(cat_inst)
+            cat_kwargs = dict(
+                config_category=config_category,
+                config_variable=self.config_variable(cat_inst),
+                mc_stats=self.mc_stats,
+            )
+            if self.skip_data:
+                cat_kwargs["data_from_processes"] = self.processes
+            else:
+                cat_kwargs["config_data_datasets"] = const.data_datasets[lep_channel]
 
-                cat_kwargs = {
-                    "config_category": f"{lep}__ml_{proc}",
-                    # "config_variable": f"mlscore.{proc}_rebin",
-                    "config_variable": f"mlscore.{proc}_manybins",
-                    "mc_stats": self.mc_stats,
-                }
-                if self.skip_data:
-                    cat_kwargs["data_from_processes"] = self.processes
-                else:
-                    cat_kwargs["config_data_datasets"] = const.data_datasets[lep]
+            self.add_category(cat_name, **cat_kwargs)
 
-                self.add_category(cat_name, **cat_kwargs)
-
-                # get the inference category to do some customization
-                cat = self.get_category(cat_name)
-                # variables that are plotting via hbw.InferencePlots for this category
-                cat.plot_variables = [f"mlscore.{proc}", "jet1_pt"]
+            # do some customization of the inference category
+            self.customize_category(self.get_category(cat_name), cat_inst)
 
     def add_inference_processes(self: InferenceModel):
         """
@@ -226,34 +257,3 @@ class HBWInferenceModelBase(InferenceModel):
                 self.add_parameter_to_group(shape_uncertainty, "theory")
             else:
                 self.add_parameter_to_group(shape_uncertainty, "experiment")
-
-
-class HBWNoMLInferenceModel(HBWInferenceModelBase):
-    def add_inference_categories(self: InferenceModel):
-        """
-        This function creates categories for the inference model
-        """
-
-        lepton_channels = self.config_inst.x.lepton_channels
-
-        for lep in lepton_channels:
-            cat_name = f"cat_{lep}"
-            if cat_name not in self.channels:
-                continue
-
-            cat_kwargs = {
-                "config_category": f"{lep}",
-                "config_variable": "mli_mbb",
-                "mc_stats": self.mc_stats,
-            }
-            if self.skip_data:
-                cat_kwargs["data_from_processes"] = self.processes
-            else:
-                cat_kwargs["config_data_datasets"] = const.data_datasets[lep]
-
-            self.add_category(cat_name, **cat_kwargs)
-
-            # get the inference category to do some customization
-            cat = self.get_category(cat_name)
-            # variables that are plotting via hbw.InferencePlots for this category
-            cat.plot_variables = ["jet1_pt"]

--- a/hbw/inference/derived.py
+++ b/hbw/inference/derived.py
@@ -5,7 +5,7 @@ hbw inference model.
 """
 
 import hbw.inference.constants as const  # noqa
-from hbw.inference.base import HBWInferenceModelBase, HBWNoMLInferenceModel
+from hbw.inference.base import HBWInferenceModelBase
 
 
 #
@@ -34,18 +34,18 @@ processes = [
     # "ggZH", "tHq", "tHW", "ggH", "qqH", "ZH", "WH", "VH", "ttH", "bbH",
 ]
 
-# All inference channels to be included in the final datacard
-channels = [
-    "cat_1e_ggHH_kl_1_kt_1_sl_hbbhww",
-    "cat_1e_qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
-    "cat_1e_tt",
-    "cat_1e_st",
-    "cat_1e_v_lep",
-    "cat_1mu_ggHH_kl_1_kt_1_sl_hbbhww",
-    "cat_1mu_qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
-    "cat_1mu_tt",
-    "cat_1mu_st",
-    "cat_1mu_v_lep",
+# All config categories to be included in the final datacard
+config_categories = [
+    "1e__ml_ggHH_kl_1_kt_1_sl_hbbhww",
+    "1e__ml_qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
+    "1e__ml_tt",
+    "1e__ml_st",
+    "1e__ml_v_lep",
+    "1mu__ml_ggHH_kl_1_kt_1_sl_hbbhww",
+    "1mu__ml_qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
+    "1mu__ml_tt",
+    "1mu__ml_st",
+    "1mu__ml_v_lep",
 ]
 
 rate_systematics = [
@@ -126,7 +126,7 @@ systematics = rate_systematics + shape_systematics
 default_cls_dict = {
     "ml_model_name": ml_model_name,
     "processes": processes,
-    "channels": channels,
+    "config_categories": config_categories,
     "systematics": systematics,
     "mc_stats": True,
     "skip_data": True,
@@ -137,10 +137,6 @@ default = HBWInferenceModelBase.derive("default", cls_dict=default_cls_dict)
 #
 # derive some additional Inference Models
 #
-
-no_ml_cls_dict = default_cls_dict.copy()
-no_ml_cls_dict["channels"] = ["cat_1e", "cat_1mu"]
-no_ml = HBWNoMLInferenceModel.derive("no_ml", cls_dict=no_ml_cls_dict)
 
 cls_dict = default_cls_dict.copy()
 
@@ -157,9 +153,9 @@ cls_dict["processes"] = [
     "st_schannel",
 ]
 
-cls_dict["channels"] = [
-    "cat_1e_ggHH_kl_1_kt_1_sl_hbbhww",
-    "cat_1e_st",
+cls_dict["config_categories"] = [
+    "1e__ml_ggHH_kl_1_kt_1_sl_hbbhww",
+    "1e__ml_st",
 ]
 
 cls_dict["systematics"] = [
@@ -170,3 +166,7 @@ cls_dict["ml_model_name"] = "dense_test"
 
 # minimal model for quick test purposes
 test = default.derive("test", cls_dict=cls_dict)
+
+# model but with different fit variable
+cls_dict["config_variable"] = lambda config_cat_inst: "jet1_pt"
+jet1_pt = default.derive("jet1_pt", cls_dict=cls_dict)

--- a/hbw/inference/derived.py
+++ b/hbw/inference/derived.py
@@ -5,7 +5,7 @@ hbw inference model.
 """
 
 import hbw.inference.constants as const  # noqa
-from hbw.inference.base import HBWInferenceModelBase
+from hbw.inference.base import HBWInferenceModelBase, HBWNoMLInferenceModel
 
 
 #
@@ -14,6 +14,7 @@ from hbw.inference.base import HBWInferenceModelBase
 
 # used to set default requirements for cf.CreateDatacards based on the config
 ml_model_name = "dense_default"
+
 # default_producers = [f"ml_{ml_model_name}", "event_weights"]
 
 # All processes to be included in the final datacard
@@ -136,6 +137,10 @@ default = HBWInferenceModelBase.derive("default", cls_dict=default_cls_dict)
 #
 # derive some additional Inference Models
 #
+
+no_ml_cls_dict = default_cls_dict.copy()
+no_ml_cls_dict["channels"] = ["cat_1e", "cat_1mu"]
+no_ml = HBWNoMLInferenceModel.derive("no_ml", cls_dict=no_ml_cls_dict)
 
 cls_dict = default_cls_dict.copy()
 

--- a/hbw/tasks/plotting.py
+++ b/hbw/tasks/plotting.py
@@ -47,7 +47,7 @@ class InferencePlots(
     categories = None
 
     inference_variables = law.CSVParameter(
-        default=("config_variable", "plot_variables"),
+        default=("config_variable", "variables_to_plot"),
         description="Inference category attributes to use to determine which variables to plot",
     )
     skip_variables = luigi.BoolParameter(default=False)


### PR DESCRIPTION
This PR changes our InferenceModel such that we can directly add categories from the config to the inference model by passing the `config_categories` attribute to our inference model.

The inference categories can be further customized by overwriting the `cat_name` and `config_variable` methods using the config category instance.