### PR TITLE
Feature/trigger matching + double counting

### DIFF
--- a/hbw/columnflow_patches.py
+++ b/hbw/columnflow_patches.py
@@ -83,8 +83,12 @@ def patch_csp_versioning():
     """
     Patches the TaskArrayFunction to add the version to the string representation of the task.
     """
+
     def TaskArrayFunction_str(self):
-        version_str = f"V{self.version}" if hasattr(self, "version") else ""
+        version = self.version() if callable(getattr(self, "version", None)) else getattr(self, "version", None)
+        if version and not isinstance(version, int):
+            raise Exception(f"version must be an integer, but is {version}")
+        version_str = f"V{version}" if version is not None else ""
         return f"{self.cls_name}{version_str}"
 
     TaskArrayFunction.__str__ = TaskArrayFunction_str

--- a/hbw/config/datasets.py
+++ b/hbw/config/datasets.py
@@ -22,10 +22,12 @@ logger = law.logger.get_logger(__name__)
 
 
 def hbw_dataset_names(config: od.Config, as_list: bool = False) -> DotDict[str: list[str]] | list[str]:
+    # define data streams based on the run
+    # NOTE: the order of the streams is important for data trigger filtering (removing double counting)
     if config.campaign.x.run == 2:
-        data_streams = ["mu", "e"]
+        config.x.data_streams = ["mu", "e"]
     elif config.campaign.x.run == 3:
-        data_streams = ["mu", "egamma", "muoneg"]
+        config.x.data_streams = ["mu", "egamma", "muoneg"]
 
     data_eras = {
         "2017": "cdef",
@@ -38,7 +40,7 @@ def hbw_dataset_names(config: od.Config, as_list: bool = False) -> DotDict[str: 
             f"data_{stream}_{era}"
             for era in data_eras
         ]
-        for stream in data_streams
+        for stream in config.x.data_streams
     }
 
     dataset_names = DotDict.wrap({

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -165,11 +165,9 @@ def set_config_defaults_and_groups(config_inst):
         "tt_all": ["tt", "tt_dl", "tt_sl", "tt_fh"],
         "st_all": ["st", "st_schannel", "st_tchannel", "st_twchannel"],
     }
-    config_inst.x.process_groups["dmuch"] = ["data_mu"] + config_inst.x.process_groups["much"]
-    config_inst.x.process_groups["d2much"] = ["data_mu"] + config_inst.x.process_groups["much"]
-    config_inst.x.process_groups["dech"] = ["data_e", "data_egamma"] + config_inst.x.process_groups["ech"]
-    config_inst.x.process_groups["d2ech"] = ["data_e", "data_egamma"] + config_inst.x.process_groups["ech"]
-    config_inst.x.process_groups["demuch"] = ["data_muoneg"] + config_inst.x.process_groups["ech"]
+    for group in ("much", "2much", "ech", "2ech", "emuch"):
+        # thanks to double counting removal, we can (and should) now use all datasets in each channel
+        config_inst.x.process_groups[f"d{group}"] = ["data"] + config_inst.x.process_groups[group]
 
     # dataset groups for conveniently looping over certain datasets
     # (used in wrapper_factory and during plotting)
@@ -260,10 +258,12 @@ def set_config_defaults_and_groups(config_inst):
     # variable groups for conveniently looping over certain variables
     # (used during plotting)
     config_inst.x.variable_groups = {
+        "sl": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
         "sl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
         "sl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*"],
-        "dl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
-        "dl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*"],
+        "dl": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht", "lt", "mll"],
+        "dl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht", "lt", "mll"],
+        "dl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*", "lt", "mll"],
         "default": ["n_jet", "n_muon", "n_electron", "ht", "m_bb", "deltaR_bb", "jet1_pt"],  # n_deepjet, ....
         "test": ["n_jet", "n_electron", "jet1_pt"],
         "cutflow": ["cf_jet1_pt", "cf_jet4_pt", "cf_n_jet", "cf_n_electron", "cf_n_muon"],  # cf_n_deepjet

--- a/hbw/config/trigger.py
+++ b/hbw/config/trigger.py
@@ -1,0 +1,415 @@
+# coding: utf-8
+
+"""
+Config-related object definitions and utils.
+"""
+
+from __future__ import annotations
+
+
+from typing import Callable, Any, Sequence
+
+import order as od
+from order import UniqueObject, TagMixin, AuxDataMixin
+from order.util import typed
+
+
+class TriggerLeg(object):
+    """
+    Container class storing information about trigger legs:
+
+        - *pdg_id*: The id of the object that should have caused the trigger leg to fire.
+        - *min_pt*: The minimum transverse momentum in GeV of the triggered object.
+        - *trigger_bits*: Integer bit mask or masks describing whether the last filter of a trigger fired.
+          See https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/triggerObjects_cff.py.
+          Per mask, any of the bits should match (*OR*). When multiple masks are configured, each of
+          them should match (*AND*).
+
+    For accepted types and conversions, see the *typed* setters implemented in this class.
+    """
+
+    def __init__(
+        self,
+        pdg_id: int | None = None,
+        min_pt: float | int | None = None,
+        trigger_bits: int | Sequence[int] | None = None,
+    ):
+        super().__init__()
+
+        # instance members
+        self._pdg_id = None
+        self._min_pt = None
+        self._trigger_bits = None
+
+        # set initial values
+        self.pdg_id = pdg_id
+        self.min_pt = min_pt
+        self.trigger_bits = trigger_bits
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__} "
+            f"'pdg_id={self.pdg_id}, min_pt={self.min_pt}, trigger_bits={self.trigger_bits}' "
+            f"at {hex(id(self))}>"
+        )
+
+    @typed
+    def pdg_id(self, pdg_id: int | None) -> int | None:
+        if pdg_id is None:
+            return None
+
+        if not isinstance(pdg_id, int):
+            raise TypeError(f"invalid pdg_id: {pdg_id}")
+
+        return pdg_id
+
+    @typed
+    def min_pt(self, min_pt: int | float | None) -> float | None:
+        if min_pt is None:
+            return None
+
+        if isinstance(min_pt, int):
+            min_pt = float(min_pt)
+        if not isinstance(min_pt, float):
+            raise TypeError(f"invalid min_pt: {min_pt}")
+
+        return min_pt
+
+    @typed
+    def trigger_bits(
+        self,
+        trigger_bits: int | Sequence[int] | None,
+    ) -> list[int] | None:
+        if trigger_bits is None:
+            return None
+
+        # cast to list
+        if isinstance(trigger_bits, tuple):
+            trigger_bits = list(trigger_bits)
+        elif not isinstance(trigger_bits, list):
+            trigger_bits = [trigger_bits]
+
+        # check bit types
+        for bit in trigger_bits:
+            if not isinstance(bit, int):
+                raise TypeError(f"invalid trigger bit: {bit}")
+
+        return trigger_bits
+
+
+class Trigger(UniqueObject, AuxDataMixin, TagMixin):
+    """
+    Container class storing information about triggers:
+
+        - *name*: The path name of a trigger that should have fired.
+        - *id*: A unique id of the trigger.
+        - *run_range*: An inclusive range describing the runs where the trigger is to be applied
+          (usually only defined by data). None in the tuple means no lower or upper boundary.
+        - *legs*: A list of :py:class:`TriggerLeg` objects contraining additional information and
+          constraints of particular trigger legs.
+        - *applies_to_dataset*: A function that obtains an ``order.Dataset`` instance to decide
+          whether the trigger applies to that dataset. Defaults to *True*.
+
+    For accepted types and conversions, see the *typed* setters implemented in this class.
+
+    In addition, a base class from *order* provides additional functionality via mixins:
+
+        - *tags*: Trigger objects can be assigned *tags* that can be checked later on, e.g. to
+          describe the type of the trigger ("single_mu", "cross", ...).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        id: int,
+        run_range: tuple[int | None, int | None] | None = None,
+        legs: Sequence[TriggerLeg] | None = None,
+        applies_to_dataset: Callable | bool | Any = True,
+        aux: Any = None,
+        tags: Any = None,
+    ):
+        UniqueObject.__init__(self, name, id)
+        AuxDataMixin.__init__(self, aux=aux)
+        TagMixin.__init__(self, tags=tags)
+
+        # force the id to be positive
+        if self.id < 0:
+            raise ValueError(f"trigger id must be positive, but found {self.id}")
+
+        # instance members
+        self._run_range = None
+        self._leg = None
+        self._applies_to_dataset = None
+
+        # set initial values
+        self.run_range = run_range
+        self.legs = legs
+        self.applies_to_dataset = applies_to_dataset
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__} 'name={self.name}, nlegs={self.n_legs}' "
+            f"at {hex(id(self))}>"
+        )
+
+    @typed
+    def name(self, name: str) -> str:
+        if not isinstance(name, str):
+            raise TypeError(f"invalid name: {name}")
+        if not name.startswith("HLT_"):
+            raise ValueError(f"invalid name: {name}")
+
+        return name
+
+    @typed
+    def run_range(
+        self,
+        run_range: Sequence[int] | None,
+    ) -> tuple[int] | None:
+        if run_range is None:
+            return None
+
+        # cast list to tuple
+        if isinstance(run_range, list):
+            run_range = tuple(run_range)
+
+        # run_range must be a tuple with two integers
+        if not isinstance(run_range, tuple):
+            raise TypeError(f"invalid run_range: {run_range}")
+        if len(run_range) != 2:
+            raise ValueError(f"invalid run_range length: {run_range}")
+        if not isinstance(run_range[0], int):
+            raise ValueError(f"invalid run_range start: {run_range[0]}")
+        if not isinstance(run_range[1], int):
+            raise ValueError(f"invalid run_range end: {run_range[1]}")
+
+        return run_range
+
+    @typed
+    def legs(
+        self,
+        legs: (
+            dict |
+            tuple[dict] |
+            list[dict] |
+            TriggerLeg |
+            tuple[TriggerLeg] |
+            list[TriggerLeg] |
+            None
+        ),
+    ) -> list[TriggerLeg]:
+        if legs is None:
+            return None
+
+        if isinstance(legs, tuple):
+            legs = list(legs)
+        elif not isinstance(legs, list):
+            legs = [legs]
+
+        _legs = []
+        for leg in legs:
+            if isinstance(leg, dict):
+                leg = TriggerLeg(**leg)
+            if not isinstance(leg, TriggerLeg):
+                raise TypeError(f"invalid trigger leg: {leg}")
+            _legs.append(leg)
+
+        return _legs or None
+
+    @typed
+    def applies_to_dataset(self, func: Callable | bool | Any) -> Callable:
+        if not callable(func):
+            decision = True if func is None else bool(func)
+            func = lambda dataset_inst: decision
+
+        return func
+
+    @property
+    def has_legs(self):
+        return bool(self._legs)
+
+    @property
+    def n_legs(self):
+        return len(self.legs) if self.has_legs else 0
+
+    @property
+    def hlt_field(self):
+        # remove the first four "HLT_" characters
+        return self.name[4:]
+
+
+from hbw.util import call_once_on_config
+
+
+@call_once_on_config()
+def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
+    """
+    Adds all triggers to a *config*. For the conversion from filter names to trigger bits, see
+    https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/triggerObjects_cff.py.
+    Electron Trigger: https://twiki.cern.ch/twiki/bin/view/CMS/EgHLTRunIIISummary
+    Muon Trigger: https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2022
+
+    Auxiliary data in use:
+    - "channels": list of channels during selection that the trigger applies to,
+    e.g. ["e", "ee", "emu", "mue"] (TODO: use this in SL aswell)
+    - "data_stream": the data stream that is associated to events that fired the trigger to
+    prevent double counting of data events
+
+    Tags are not being used at the moment.
+    """
+    # only 2022 triggers for now
+    single_mu = Trigger(
+        name="HLT_IsoMu24",
+        id=101,
+        legs=[
+            TriggerLeg(
+                pdg_id=13,
+                min_pt=25.0,
+                # filter names:
+                # hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08 (1mu + Iso)
+                trigger_bits=2**1 + 2**3,  # Iso (bit 1) + 1mu (bit 3)
+            ),
+        ],
+        aux={
+            "channels": ["mu", "mm", "emu", "mue", "mixed"],
+            "data_stream": "data_mu",
+        },
+        tags={"single_trigger", "single_mu"},
+    )
+    di_mu = Trigger(
+        name="HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8",
+        id=102,
+        legs=[
+            TriggerLeg(
+                pdg_id=13,
+                min_pt=18.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**0 + 2**4,  # TrkIsoVVL (bit 0) + 2mu (bit 4)
+            ),
+            TriggerLeg(
+                pdg_id=13,
+                min_pt=9.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**0 + 2**4,  # TrkIsoVVL (bit 0) + 2mu (bit 4) + DZ_Mass3p8 (bit ?)
+            ),
+        ],
+        aux={
+            "channels": ["mm"],
+            "data_stream": "data_mu",
+        },
+        tags={"di_trigger", "di_mu"},
+    )
+    single_e = Trigger(
+        name="HLT_Ele30_WPTight_Gsf",
+        id=201,
+        legs=[
+            TriggerLeg(
+                pdg_id=11,
+                min_pt=31.0,
+                # filter names:
+                # hltEle30WPTightGsfTrackIsoFilter
+                trigger_bits=2**1,  # 1e (WPTight) (bit 1)
+            ),
+        ],
+        aux={
+            "channels": ["e", "ee", "emu", "mue", "mixed"],
+            "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+        },
+        tags={"single_trigger", "single_e"},
+    )
+    di_e = Trigger(
+        # CaloIdL_TrackIdL_IsoVL only for the second leg?
+        name="HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL",
+        id=202,
+        legs=[
+            TriggerLeg(
+                pdg_id=11,
+                min_pt=24.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**4 + 2**0,  # 2e (bit 4) + CaloIdL_TrackIdL_IsoVL (bit 0)
+            ),
+            TriggerLeg(
+                pdg_id=11,
+                min_pt=13.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**4 + 2**0,  # 2e (bit 4) + CaloIdL_TrackIdL_IsoVL (bit 0)
+            ),
+        ],
+        aux={
+            "channels": ["ee"],
+            "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+        },
+        tags={"di_trigger", "di_e"},
+    )
+    mixed_mue = Trigger(
+        name="HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL",
+        id=301,
+        legs=[
+            TriggerLeg(
+                pdg_id=13,
+                min_pt=24.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**5 + 2**0,  # 1e-1mu (bit 5) + TrkIsoVVL (bit 0)
+            ),
+            TriggerLeg(
+                pdg_id=11,
+                min_pt=13.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**5 + 2**0,  # 1mu-1e (bit 5) + CaloIdL_TrackIdL_IsoVL (bit 0)
+            ),
+        ],
+        aux={
+            "channels": ["mue", "mixed"],
+            "data_stream": "data_muoneg",
+        },
+        tags={"mixed_trigger", "mixed_mue"},
+    )
+    mixed_emu = Trigger(
+        name="HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL",
+        id=401,
+        legs=[
+            TriggerLeg(
+                pdg_id=13,
+                min_pt=9.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**5 + 2**0,  # 1mu-1e (bit 5) + TrkIsoVVL (bit 0)
+            ),
+            TriggerLeg(
+                pdg_id=11,
+                min_pt=24.0,
+                # filter names:
+                # TODO
+                trigger_bits=2**5 + 2**0,  # 1mu-1e (bit 5) + CaloIdL_TrackIdL_IsoVL (bit 0)
+            ),
+        ],
+        aux={
+            "channels": ["emu", "mixed"],
+            "data_stream": "data_muoneg",
+        },
+        tags={"mixed_trigger", "mixed_emu"},
+    )
+
+    # add triggers to the config
+    if config.has_tag("is_dl"):
+        config.x.triggers = od.UniqueObjectIndex(Trigger, [
+            single_e,
+            single_mu,
+            di_e,
+            di_mu,
+            mixed_mue,
+            mixed_emu,
+        ])
+    elif config.has_tag("is_sl"):
+        config.x.triggers = od.UniqueObjectIndex(Trigger, [
+            single_e,
+            single_mu,
+        ])
+    else:
+        raise ValueError("Analysis, please set the 'is_dl' or 'is_sl' tag")

--- a/hbw/config/variables.py
+++ b/hbw/config/variables.py
@@ -296,6 +296,7 @@ def add_variables(config: od.Config) -> None:
         unit="GeV",
         x_title=r"$m_{ll}$",
     )
+    # TODO: add ptll variable (needs behaviour or running producers)
 
     config.add_variable(
         name="n_jet",
@@ -405,6 +406,16 @@ def add_variables(config: od.Config) -> None:
         x_title="HT",
     )
     config.add_variable(
+        name="lt",
+        expression=lambda events: (
+            ak.sum(events.Muon.pt, axis=1) + ak.sum(events.Muon.pt, axis=1) + events.MET.pt
+        ),
+        aux={"inputs": {"Muon.pt", "Electron.pt", "MET.pt"}},
+        binning=(40, 0, 1200),
+        unit="GeV",
+        x_title="LT",
+    )
+    config.add_variable(
         name="ht_bjet_norm",
         expression=lambda events: ak.sum(events.Jet.pt, axis=1),
         aux={"inputs": {"Jet.pt"}},
@@ -423,13 +434,6 @@ def add_variables(config: od.Config) -> None:
         binning=(40, 0, 400),
         unit="GeV",
         x_title="$p_{T}$ of all jets",
-    )
-    config.add_variable(
-        name="muons_pt",
-        expression="Muon.pt",
-        binning=(40, 0, 400),
-        unit="GeV",
-        x_title="$p_{T}$ of all muons",
     )
 
     # Jets (4 pt-leading jets)

--- a/hbw/selection/sl_remastered.py
+++ b/hbw/selection/sl_remastered.py
@@ -116,7 +116,7 @@ def sl_lepton_selection(
             trigger_mask = ak_any([events.HLT[trigger_column] for trigger_column in trigger_columns], axis=0)
         else:
             # if no trigger is defined, we assume that the event passes the trigger
-            trigger_mask = np.ones(len(events), dtype=np.bool)
+            trigger_mask = np.ones(len(events), dtype=np.bool_)
         lepton_results.steps[f"Trigger_{channel}"] = trigger_mask
 
         # ensure that Lepton channel is in agreement with trigger

--- a/hbw/selection/trigger.py
+++ b/hbw/selection/trigger.py
@@ -1,0 +1,310 @@
+# coding: utf-8
+
+"""
+Trigger selection methods.
+"""
+import law
+
+from functools import partial
+from collections import defaultdict
+
+from columnflow.selection import Selector, SelectionResult, selector
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column, optional_column as optional
+
+from hbw.util import ak_any
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+# helper functions
+set_ak_bool = partial(set_ak_column, value_type=np.bool_)
+set_ak_int32 = partial(set_ak_column, value_type=np.int32)
+
+# logger
+logger = law.logger.get_logger(__name__)
+
+
+@selector(
+    uses={
+        "run",
+        # nano columns
+        "TrigObj.id", "TrigObj.pt", "TrigObj.eta", "TrigObj.phi", "TrigObj.filterBits",
+    },
+    produces={
+        # new columns
+        "trigger_ids",
+    },
+)
+def trigger_selection(
+    self: Selector,
+    events: ak.Array,
+    stats: defaultdict,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    HLT trigger path selection.
+
+    NOTE: to use this selector, the *triggers* auxiliary must be set in the config.
+    """
+    trigger_ids = []
+
+    trigger_data = ak.Array({
+        "any_fired": ak.zeros_like(events.run, dtype=np.bool_),
+    })
+
+    # index of TrigObj's to repeatedly convert masks to indices
+    index = ak.local_index(events.TrigObj)
+
+    for trigger in self.config_inst.x.triggers:
+        # # skip the trigger if it does not apply to the dataset
+        # if not trigger.applies_to_dataset(self.dataset_inst):
+        #     continue
+
+        # get bare decisions
+        fired = events.HLT[trigger.hlt_field] == 1
+        if trigger.run_range:
+            fired = fired & (
+                ((trigger.run_range[0] is None) | (trigger.run_range[0] <= events.run)) &
+                ((trigger.run_range[1] is None) | (trigger.run_range[1] >= events.run))
+            )
+        trigger_data = set_ak_bool(trigger_data, f"{trigger.name}.fired", fired)
+        trigger_data = set_ak_bool(trigger_data, "any_fired", trigger_data.any_fired | fired)
+
+        # get trigger objects for fired events per leg
+        leg_masks = []
+        all_legs_match = True
+        leg_match_or = False
+        for i, leg in enumerate(trigger.legs):
+            # start with a True mask
+            leg_mask = abs(events.TrigObj.id) >= 0
+            # pdg id selection
+            if leg.pdg_id is not None:
+                leg_mask = leg_mask & (abs(events.TrigObj.id) == leg.pdg_id)
+            # pt cut
+            if leg.min_pt is not None:
+                leg_mask = leg_mask & (events.TrigObj.pt >= leg.min_pt)
+            # trigger bits match
+            if leg.trigger_bits is not None:
+                # OR across bits themselves, AND between all decision in the list
+                for bits in leg.trigger_bits:
+                    # NOTE: changed
+                    # leg_mask = leg_mask & ((events.TrigObj.filterBits & bits) > 0)
+                    leg_mask = leg_mask & ((events.TrigObj.filterBits & bits) == bits)
+            leg_masks.append(index[leg_mask])
+
+            trigger_data = set_ak_bool(
+                trigger_data,
+                f"{trigger.name}.leg_{i}_mask",
+                leg_mask,
+            )
+            # at least one object must match this leg
+            # NOTE: it could in theory happen, that two legs are matched to the same object.
+            # However, as long as the correct trigger bits are required (e.g. 2mu), this
+            # might not be an actual problem (leg2 is always a sub-set of leg1 (?))
+            all_legs_match = all_legs_match & ak.any(leg_mask, axis=1)
+            leg_match_or = leg_match_or | leg_mask
+
+        # final trigger decision
+        fired_and_all_legs_match = fired & all_legs_match
+
+        # store all intermediate results for subsequent selectors
+        trigger_data = set_ak_bool(
+            trigger_data,
+            f"{trigger.name}.all_legs_match",
+            all_legs_match,
+        )
+        trigger_data = set_ak_bool(
+            trigger_data,
+            f"{trigger.name}.fired_and_all_legs_match",
+            fired_and_all_legs_match,
+        )
+        ids = ak.where(fired_and_all_legs_match, np.float32(trigger.id), np.float32(np.nan))
+        trigger_ids.append(ak.singletons(ak.nan_to_none(ids)))
+
+    # store the fired trigger ids
+    trigger_ids = ak.concatenate(trigger_ids, axis=1)
+    events = set_ak_int32(events, "trigger_ids", trigger_ids)
+
+    return events, SelectionResult(
+        steps={
+            "trigger": trigger_data.any_fired,
+        },
+        aux={
+            "trigger_data": trigger_data,
+        },
+    )
+
+
+@trigger_selection.init
+def trigger_selection_init(self: Selector) -> None:
+    if getattr(self, "config_inst", None) is None:
+        return
+    if getattr(self, "dataset_inst", None) is None:
+        return
+
+    # full used columns
+    self.uses |= {
+        optional(trigger.name)
+        for trigger in self.config_inst.x.triggers
+        # if trigger.applies_to_dataset(self.dataset_inst)
+    }
+
+    # testing: add HLT columns to keep columns
+    self.config_inst.x.keep_columns["cf.ReduceEvents"] |= {
+        f"HLT.{trigger.hlt_field}"
+        for trigger in self.config_inst.x.triggers
+        # if trigger.applies_to_dataset(self.dataset_inst)
+    }
+
+
+@selector(
+    uses={"run", "trigger_ids"},
+)
+def trigger_lepton_crosscheck(
+    self: Selector,
+    events: ak.Array,
+    lepton_results: SelectionResult,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    This Selector ensures that the trigger selection is consistent with the lepton selection.
+    e.g. events can only pass the ee selection if one of the ee triggers fired and at least two
+    electrons have been selected.
+
+    Requires the *trigger_selection* and *lepton_selection* selectors to be run before.
+    The lepton_results are expected to contain steps starting with "Lep_".
+
+    The trigger config objects are expected to have a *channels* attribute, which is a list of
+    lepton channels that the trigger applies to (same names as the "Lep" channels).
+    """
+    # initialize the result object
+    trigger_lepton_result = SelectionResult()
+
+    # get all lepton channels from the lepton selection results
+    channels = [step.replace("Lep_", "") for step in lepton_results.steps if step.startswith("Lep_")]
+
+    triggers_dict = {
+        channel: [trigger for trigger in self.config_inst.x.triggers if channel in trigger.x.channels]
+        for channel in channels
+    }
+
+    def trigger_fired(events, triggers):
+        if not triggers:
+            return np.zeros(len(events), dtype=np.bool_)
+        # check if one of the triggers fired
+        return ak_any([ak.any(events.trigger_ids == trig.id, axis=1) for trig in triggers])
+
+    for channel, triggers in triggers_dict.items():
+        if not triggers:
+            logger.warning(f"no triggers found for channel '{channel}'")
+            continue
+
+        # start with mask of events where triggers for this process fired
+        trigger_mask = trigger_fired(events, triggers_dict[channel])
+        trigger_lepton_result.steps[f"Trigger_{channel}"] = trigger_mask
+
+        # check if the trigger selection is consistent with the lepton selection
+        trigger_lepton_result.steps[f"TriggerAndLep_{channel}"] = trigger_mask & lepton_results.steps[f"Lep_{channel}"]
+
+    # combine results of each individual channel
+    trigger_lepton_result.steps["Trigger"] = ak_any([
+        trigger_lepton_result.steps[f"Trigger_{channel}"]
+        for channel in channels
+    ])
+    trigger_lepton_result.steps["TriggerAndLep"] = ak_any([
+        trigger_lepton_result.steps[f"TriggerAndLep_{channel}"]
+        for channel in channels
+    ])
+
+    return events, trigger_lepton_result
+
+
+@selector(
+    uses={"run", "trigger_ids"},
+)
+def data_double_counting(
+    self: Selector,
+    events: ak.Array,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    Data double counting removal.
+
+    The idea is as follows:
+    - Each trigger defines one data stream that it belongs to via a tag.
+    - We start with a mask that removes all events where triggers from this stream did not fire.
+    - In the config, we define the order of the data stream priorities. When a trigger from a higher
+        priority data stream fires, the event is removed
+    """
+
+    if self.dataset_inst.is_mc:
+        # return always true for MC
+        return events, SelectionResult(steps={"data_double_counting": np.ones(len(events), dtype=np.bool_)})
+
+    process_inst = self.dataset_inst.processes.get_first()
+
+    data_processes_ordered = [f"data_{stream}" for stream in self.config_inst.x.data_streams]
+    if process_inst.name not in data_processes_ordered:
+        raise Exception(f"data process {process_inst.name} not known for double counting removal")
+
+    double_counting_result = SelectionResult()
+
+    triggers_dict = {
+        data_process: [trigger for trigger in self.config_inst.x.triggers if trigger.x.data_stream == data_process]
+        for data_process in data_processes_ordered
+    }
+
+    def trigger_fired(events, triggers):
+        if not triggers:
+            return np.zeros(len(events), dtype=np.bool_)
+        # check if one of the triggers fired
+        return ak_any([ak.any(events.trigger_ids == trig.id, axis=1) for trig in triggers])
+
+    # start with mask of events where triggers for this process fired
+    double_counting_mask = trigger_fired(events, triggers_dict[process_inst.name])
+
+    skip_veto = False
+    for data_process in data_processes_ordered:
+        if data_process == process_inst.name:
+            # when arriving at the current process, we are done; loop over the triggers of the
+            # remaining processes is only done for cross checks
+            skip_veto = True
+
+        # check if one of the triggers fired (and therefore belongs to some other data stream)
+        fired = trigger_fired(events, triggers_dict[data_process])
+        double_counting_result.steps[f"Trigger_{data_process}"] = fired
+
+        if not skip_veto:
+            # remove events that fired triggers from other data streams
+            double_counting_mask = double_counting_mask & ~fired
+
+    double_counting_result.steps["data_double_counting"] = double_counting_mask
+
+    return events, double_counting_result
+
+
+@selector(
+    uses={trigger_selection, trigger_lepton_crosscheck, data_double_counting},
+    produces={trigger_selection, trigger_lepton_crosscheck, data_double_counting},
+)
+def hbw_trigger_selection(
+    self: Selector,
+    events: ak.Array,
+    lepton_results: SelectionResult,
+    stats: defaultdict,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    Wrapper of all trigger selection methods.
+    """
+    # apply trigger selection methods
+    events, trigger_result = self[trigger_selection](events, stats, **kwargs)
+    events, trigger_lepton_result = self[trigger_lepton_crosscheck](events, lepton_results, **kwargs)
+    events, double_counting_result = self[data_double_counting](events, **kwargs)
+
+    # combine results
+    hbw_trigger_result = trigger_result + trigger_lepton_result + double_counting_result
+
+    return events, hbw_trigger_result


### PR DESCRIPTION
This PR adds trigger object matching and cross cleaning between different data streams.
To achieve the trigger object matching, the trigger Selector has been reimplemented using a newly created `Trigger` collection from the config.

The strategy for the cross cleaning is as follows:
- Each trigger defines one data stream that it belongs to via a tag.
- We start with a mask that removes all events where triggers from this stream did not fire.
- In the config, we define the order of the data stream priorities. When a trigger from a higher
        priority data stream fires, the event is removed

Our data stream priority is data_mu>data_egamma>data_muoneg. Therefore events are kept as follows:
- a single/dimuon trigger fired --> event is kept in data_mu and removed in all other streams
- a single/dielectron trigger fired and no single/dimuon trigger fired --> events is kept in data_egamma and removed in all other streams
- a mixed (emu) trigger fired and single/dimuon and no single/dielectron trigger fired --> events are kept in data_muoneg and removed in all other streams
- no trigger fired --> events are removed in all streams

This means that we can (and need to) run over all data streams independent of the lepton channel when creating data/mc plots.

Currently, the trigger selection simply uses all triggers that are present in the `cfg.x.triggers` collection. To customize our dl selector, we can overwrite the `trigger_config_func` attribute via `derive`, which is a function that can modify the config during the init call of our selector.

TODO: we still need to implement these new selectors in the sl selector.