### PR TITLE
Feature/calibrations cleanup

### DIFF
--- a/hbw/calibration/default.py
+++ b/hbw/calibration/default.py
@@ -53,7 +53,6 @@ def ele(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
 
     # apply the electron calibration
     events = self[self.electron_calib_cls](events, **kwargs)
-
     return events
 
 
@@ -152,6 +151,7 @@ fatjet_test = fatjet.derive("fatjet_test")
     # jec uncertainty_sources: set to None to use config default
     jec_sources=["Total"],
     bjet_regression=True,
+    skip_jer=False,
     version=1,
 )
 def jet_base(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
@@ -243,7 +243,7 @@ def jet_base_init(self: Calibrator) -> None:
 
     # JER (only for MC)
     jer_cls = self.config_inst.x.calib_deterministic_jer_cls
-    if self.dataset_inst.is_mc:
+    if self.dataset_inst.is_mc and not self.skip_jer:
         self.calibrators.append(jer_cls)
 
     # MET phi (only in run 2)
@@ -255,6 +255,8 @@ def jet_base_init(self: Calibrator) -> None:
     self.produces |= set(self.calibrators)
 
 
-skip_jecunc = jet_base.derive("skip_jecunc", cls_dict=dict(bjet_regression=False))
+jec_only = jet_base.derive("jec_only", cls_dict=dict(bjet_regression=False, skip_jer=True))
+skip_jer = jet_base.derive("skip_jer", cls_dict=dict(bjet_regression=True, skip_jer=True))
+no_breg = jet_base.derive("no_breg", cls_dict=dict(bjet_regression=False))
 with_b_reg = jet_base.derive("with_b_reg", cls_dict=dict(bjet_regression=True))
 with_b_reg_test = jet_base.derive("with_b_reg_test", cls_dict=dict(bjet_regression=True))

--- a/hbw/calibration/jet.py
+++ b/hbw/calibration/jet.py
@@ -10,7 +10,6 @@ import functools
 
 from columnflow.util import maybe_import, try_float
 from columnflow.columnar_util import set_ak_column
-from columnflow.calibration.cms.jets import jec
 from columnflow.calibration import calibrator, Calibrator
 
 
@@ -24,9 +23,9 @@ ak = maybe_import("awkward")
 
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
-
-# custom jec calibrator that only runs nominal correction
-jec_nominal = jec.derive("jec_nominal", cls_dict={"uncertainty_sources": ["Total"]})
+#
+# BJet calibrator
+#
 
 
 @calibrator(

--- a/hbw/categorization/categories.py
+++ b/hbw/categorization/categories.py
@@ -13,7 +13,7 @@ from columnflow.categorization import Categorizer, categorizer
 from columnflow.selection import SelectionResult
 from columnflow.columnar_util import has_ak_column, optional_column
 
-from hbw.util import MET_COLUMN
+from hbw.util import MET_COLUMN, BTAG_COLUMN
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -123,6 +123,23 @@ catid_1mu = catid_lep.derive("catid_1mu", cls_dict={"n_electron": 0, "n_muon": 1
 catid_2e = catid_lep.derive("catid_2e", cls_dict={"n_electron": 2, "n_muon": 0})
 catid_2mu = catid_lep.derive("catid_2mu", cls_dict={"n_electron": 0, "n_muon": 2})
 catid_emu = catid_lep.derive("catid_emu", cls_dict={"n_electron": 1, "n_muon": 1})
+
+
+@categorizer(
+    uses={"{Muon,Electron}.pt"},
+)
+def catid_ge3lep(
+    self: Categorizer, events: ak.Array, results: SelectionResult | None = None, **kwargs,
+) -> tuple[ak.Array, ak.Array]:
+    if results:
+        electron = events.Electron[results.objects.Electron.Electron]
+        muon = events.Muon[results.objects.Muon.Muon]
+    else:
+        electron = events.Electron
+        muon = events.Muon
+
+    mask = ak.sum(electron.pt > 0, axis=-1) + ak.sum(muon.pt > 0, axis=-1) >= 3
+    return events, mask
 
 
 #
@@ -244,9 +261,6 @@ def catid_njet3(
         return events, results.steps.nJet3
     mask = ak.num(events.Jet.pt, axis=-1) >= 3
     return events, mask
-
-
-from hbw.util import BTAG_COLUMN
 
 
 @categorizer(uses={BTAG_COLUMN("Jet")})

--- a/hbw/categorization/categories.py
+++ b/hbw/categorization/categories.py
@@ -301,3 +301,13 @@ for proc in ml_processes:
             outp_mask = outp_mask & mask
 
         return events, outp_mask
+
+
+@categorizer(uses={"{Electron,Muon}.{pt,eta,phi,mass}", "mll"})
+def mask_fn_highpt(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    """
+    Categorizer that selects events in the phase space that we understand.
+    Needs to be used in combination with a Producer that defines the leptons.
+    """
+    mask = (events.Lepton[:, 0].pt > 70) & (events.Lepton[:, 1].pt > 50) & (events.mll > 20)
+    return events, mask

--- a/hbw/config/categories.py
+++ b/hbw/config/categories.py
@@ -1,3 +1,4 @@
+
 # coding: utf-8
 
 """
@@ -136,7 +137,7 @@ def add_mll_categories(config: od.Config) -> None:
 def add_lepton_categories(config: od.Config) -> None:
     config.x.lepton_channels = {
         "sl": ("1e", "1mu"),
-        "dl": ("2e", "2mu", "emu"),
+        "dl": ("2e", "2mu", "emu", "ge3lep"),
     }[config.x.lepton_tag]
 
     cat_1e = config.add_category(  # noqa: F841
@@ -172,6 +173,13 @@ def add_lepton_categories(config: od.Config) -> None:
         id=50,
         selection="catid_emu",
         label="1 Electron 1 Muon",
+    )
+
+    cat_emu = config.add_category(  # noqa: F841
+        name="ge3lep",
+        id=60,
+        selection="catid_ge3lep",
+        label=r"$N_{lep} \geq 3$",
     )
 
 

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -680,6 +680,10 @@ def add_config(
     add_external("trigger_sf_mm", (f"{trigger_sf_path}/sf_mm_mli_lep_pt-trig_ids.json", "v2"))
     add_external("trigger_sf_mixed", (f"{trigger_sf_path}/sf_mixed_mli_lep_pt-trig_ids.json", "v2"))  # noqa: E501
 
+    # trigger
+    from hbw.config.trigger import add_triggers
+    add_triggers(cfg)
+
     # btag scale factor
     add_external("btag_sf_corr", (f"{json_mirror}/POG/BTV/{corr_tag}/btagging.json.gz", "v2"))
     # V+jets reweighting (derived for 13 TeV, custom json converted from ROOT, not centrally produced)
@@ -787,9 +791,23 @@ def add_config(
         "VetoTau.{pt,eta,phi,mass,decayMode}",
         # MET
         "{MET,PuppiMET}.{pt,phi}",
+        # steps
+        "steps.*",
+        # Trigger-related
+        "trigger_ids", "trigger_data.*",
+        "HLT.IsoMu24",
+        "HLT.Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8",
+        "HLT.Ele30_WPTight_Gsf",
+        "HLT.Ele23_Ele12_CaloIdL_TrackIdL_IsoVL",
+        "HLT.Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
+        "HLT.Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
+        "HLT.Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL",
+        # "TrigObj.{pt,eta,phi,mass,filterBits}",  # NOTE: this column is very large (~1/3 of final reduced events)
         # all columns added during selection using a ColumnCollection flag, but skip cutflow ones
         ColumnCollection.ALL_FROM_SELECTOR,
         skip_column("cutflow.*"),
+    } | {
+        "HLT.{trg.hlt_field}" for trg in cfg.get_aux("triggers", [])
     }
 
     # Version of required tasks

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -326,9 +326,9 @@ def add_config(
     # https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL17?rev=17
     cfg.x.btag_working_points = DotDict.wrap({
         "deepjet": {
-            "loose": {"2016preVFP": 0.0508, "2016postVFP": 0.0480, "2017": 0.0532, "2018": 0.0490, "2022preEE": 0.0583, "2022postEE": 0.0614, "2023": 0.0479, "2023BPix": 0.048}.get(cfg.x.cpn_tag, 0.0),  # noqa
-            "medium": {"2016preVFP": 0.2598, "2016postVFP": 0.2489, "2017": 0.3040, "2018": 0.2783, "2022preEE": 0.3086, "2022postEE": 0.3196, "2023": 0.2431, "2023BPix": 0.2435}.get(cfg.x.cpn_tag, 0.0),  # noqa
-            "tight": {"2016preVFP": 0.6502, "2016postVFP": 0.6377, "2017": 0.7476, "2018": 0.7100, "2022preEE": 0.7183, "2022postEE": 0.73, "2023": 0.6553, "2023BPix": 0.6563}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "loose": {"2016preVFP": 0.0508, "2016postVFP": 0.0480, "2017": 0.0532, "2018": 0.0490, "2022preEE": 0.0583, "2022postEE": 0.0614, "2023preBPix": 0.0479, "2023BPix": 0.048}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "medium": {"2016preVFP": 0.2598, "2016postVFP": 0.2489, "2017": 0.3040, "2018": 0.2783, "2022preEE": 0.3086, "2022postEE": 0.3196, "2023preBPix": 0.2431, "2023BPix": 0.2435}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "tight": {"2016preVFP": 0.6502, "2016postVFP": 0.6377, "2017": 0.7476, "2018": 0.7100, "2022preEE": 0.7183, "2022postEE": 0.73, "2023preBPix": 0.6553, "2023BPix": 0.6563}.get(cfg.x.cpn_tag, 0.0),  # noqa
         },
         "deepcsv": {
             "loose": {"2016preVFP": 0.2027, "2016postVFP": 0.1918, "2017": 0.1355, "2018": 0.1208}.get(cfg.x.cpn_tag, 0.0),  # noqa
@@ -336,9 +336,9 @@ def add_config(
             "tight": {"2016preVFP": 0.8819, "2016postVFP": 0.8767, "2017": 0.7738, "2018": 0.7665}.get(cfg.x.cpn_tag, 0.0),  # noqa
         },
         "particlenet": {
-            "loose": {"2022preEE": 0.047, "2022postEE": 0.0499, "2023": 0.0358, "2023BPix": 0.359}.get(cfg.x.cpn_tag, 0.0),  # noqa
-            "medium": {"2022preEE": 0.245, "2022postEE": 0.2605, "2023": 0.1917, "2023BPix": 0.1919}.get(cfg.x.cpn_tag, 0.0),  # noqa
-            "tight": {"2022preEE": 0.6734, "2022postEE": 0.6915, "2023": 0.6172, "2023BPix": 0.6133}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "loose": {"2022preEE": 0.047, "2022postEE": 0.0499, "2023preBPix": 0.0358, "2023postBPix": 0.359}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "medium": {"2022preEE": 0.245, "2022postEE": 0.2605, "2023preBPix": 0.1917, "2023postBPix": 0.1919}.get(cfg.x.cpn_tag, 0.0),  # noqa
+            "tight": {"2022preEE": 0.6734, "2022postEE": 0.6915, "2023preBPix": 0.6172, "2023postBPix": 0.6133}.get(cfg.x.cpn_tag, 0.0),  # noqa
         },
     })
 
@@ -365,6 +365,8 @@ def add_config(
     cfg.x.btag_wp_score = (
         cfg.x.btag_working_points[cfg.x.b_tagger][cfg.x.btag_wp]
     )
+    if cfg.x.btag_wp_score == 0.0:
+        raise ValueError(f"Unknown b-tag working point '{cfg.x.btag_wp}' for campaign {cfg.x.cpn_tag}")
 
     # met configuration
     cfg.x.met_name = {

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -28,6 +28,7 @@ from hbw.util import timeit_multiple
 from columnflow.production.cms.electron import ElectronSFConfig
 from columnflow.production.cms.muon import MuonSFConfig
 from columnflow.production.cms.btag import BTagSFConfig
+from columnflow.calibration.cms.egamma import EGammaCorrectionConfig
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
 
@@ -414,9 +415,13 @@ def add_config(
 
     ################################################################################################
     #
-    # electron and muon SFs (NOTE: we could add these config entries as part of the selector init)
+    # electron and muon calibrations and SFs (NOTE: we could add these config entries as part of the selector init)
     #
     ################################################################################################
+
+    # electron calibrations
+    cfg.x.eec = EGammaCorrectionConfig(correction_set="Scale")
+    cfg.x.eer = EGammaCorrectionConfig(correction_set="Smearing")
 
     if cfg.x.run == 2:
         # names of electron correction sets and working points
@@ -431,7 +436,6 @@ def add_config(
         # (used in the muon producer)
         cfg.x.muon_id_sf_names = ("NUM_TightID_DEN_TrackerMuons", f"{cfg.x.cpn_tag}_UL")
         cfg.x.muon_iso_sf_names = ("NUM_TightRelIso_DEN_TightIDandIPCut", f"{cfg.x.cpn_tag}_UL")
-
     elif cfg.x.run == 3:
         electron_sf_campaign = {
             "2022postEE": "2022Re-recoE+PromptFG",
@@ -659,7 +663,9 @@ def add_config(
     add_external("jet_veto_map", (f"{json_mirror}/POG/JME/{corr_tag}/jetvetomaps.json.gz", "v1"))
     # electron scale factors
     add_external("electron_sf", (f"{json_mirror}/POG/EGM/{corr_tag}/electron.json.gz", "v1"))
-    # add_external("electron_ss", (f"{json_mirror}/POG/EGM/{corr_tag}/electronSS.json.gz", "v1"))
+    if year != 2023:
+        # missing in 2023
+        add_external("electron_ss", (f"{json_mirror}/POG/EGM/{corr_tag}/electronSS.json.gz", "v1"))
     # muon scale factors
     add_external("muon_sf", (f"{json_mirror}/POG/MUO/{corr_tag}/muon_Z.json.gz", "v1"))
     # trigger_sf from Balduin

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -8,7 +8,8 @@ from hbw.util import bracket_expansion
 
 
 def default_calibrator(container):
-    return ["with_b_reg", "fatjet"]
+    # return ["with_b_reg", "fatjet"]
+    return ["no_breg", "fatjet", "ele"]
 
 
 def default_selector(container):
@@ -166,23 +167,20 @@ def set_config_defaults_and_groups(config_inst):
             "h",
         ],
         "all": ["*"],
-        "default": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "tt", "dy", "st", "vv", "w_lnu", "h"],  # noqa: E501
-        "sl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "tt", "qcd", "st", "dy", "vv", "w_lnu", "h"],  # noqa: E501
-        "much": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "tt", "qcd", "st", "dy", "vv", "w_lnu", "h"],  # noqa: E501
-        "ech": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "tt", "qcd", "st", "dy", "vv", "w_lnu", "h"],  # noqa: E501
-        "dl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "tt", "dy", "st", "vv", "w_lnu", "h"],  # noqa: E501
-        "dl1": [default_signal_process, "tt", "dy", "st", "ttv", "vv", "w_lnu", "h"],
-        "dl2": [default_signal_process, "tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "st", "ttv", "vv", "w_lnu", "h"],  # noqa: E501
-        "dl3": [default_signal_process, "tt", "dy_m10to50", "dy_m50toinf", "st", "ttv", "vv", "w_lnu", "h"],  # noqa: E501
-        "dlbkg": ["tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "st", "ttv", "vv", "w_lnu", "h"],
-        "dlmajor": [default_signal_process, "tt", "dy", "st"],
-        "2much": [default_signal_process, "tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "st", "vv", "w_lnu", "h"],
-        "2ech": [default_signal_process, "tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "st", "vv", "w_lnu", "h"],
-        "emuch": [default_signal_process, "tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "st", "vv", "w_lnu", "h"],
-        # "dl": [default_signal_process, "tt", "dy", "st", "vv", "w_lnu", "h"],
-        # "2much": [default_signal_process, "tt", "dy", "st", "vv", "w_lnu", "h"],
-        # "2ech": [default_signal_process, "tt", "dy", "st", "vv", "w_lnu", "h"],
-        # "emuch": [default_signal_process, "tt", "dy", "st", "vv", "w_lnu", "h"],
+        "default": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "st", "dy", "tt"],  # noqa: E501
+        "sl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "dy", "st", "qcd", "tt"],  # noqa: E501
+        "much": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "dy", "st", "qcd", "tt"],  # noqa: E501
+        "ech": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "dy", "st", "qcd", "tt"],  # noqa: E501
+        "dl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "st", "dy", "tt"],  # noqa: E501
+        "dl1": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy", "tt"],
+        "dl2": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dl3": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "table": [default_signal_process, "st", "dy_m10to50", "dy_m50toinf", "tt", "background", "data"],  # noqa: E501
+        "dlbkg": ["tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "h", "ttv", "vv", "w_lnu", "st", "dy", "tt"],
+        "dlmajor": [default_signal_process, "st", "dy", "tt"],
+        "2much": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "2ech": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "emuch": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
         "inference": ["hh_ggf_*", "tt", "st", "w_lnu", "dy", "qcd_*"],
         "k2v": ["hh_vbf_*", "tt", "st", "w_lnu", "dy", "qcd_*"],
         "ml": [default_signal_process, "tt", "st", "w_lnu", "dy"],

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -437,7 +437,6 @@ def set_config_defaults_and_groups(config_inst):
                 "ncols": 2,
                 "fontsize": 16,
                 "bbox_to_anchor": (0., 0., 1., 1.),
-                "reverse": True,
             },
             "annotate_cfg": {
                 "xy": (0.05, 0.95),

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -175,6 +175,8 @@ def set_config_defaults_and_groups(config_inst):
         "dl1": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy", "tt"],
         "dl2": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
         "dl3": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dlmu": ["data_mu", default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dleg": ["data_egamma", default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
         "table": [default_signal_process, "st", "dy_m10to50", "dy_m50toinf", "tt", "background", "data"],  # noqa: E501
         "dlbkg": ["tt", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "h", "ttv", "vv", "w_lnu", "st", "dy", "tt"],
         "dlmajor": [default_signal_process, "st", "dy", "tt"],
@@ -261,6 +263,7 @@ def set_config_defaults_and_groups(config_inst):
         "dl": ["sr", "dycr", "ttcr", "sr__1b", "sr__2b", "dycr__1b", "dycr__2b", "ttcr__1b", "ttcr__2b"],
         "dl_preml_small": bracket_expansion(["incl", "{sr,ttcr,dycr}{,__2e,__2mu,__emu}__resolved{,__1b,__2b}"]),
         "dl_preml_large": bracket_expansion(["incl", "{,sr__,ttcr__,dycr__}{,2e__,2mu__,emu__}resolved{,__1b,__2b}"]),
+        "dl_preml_1": bracket_expansion(["incl", "{,sr,ttcr,dycr}__{,2e,2mu,emu}"]),
         "dl_preml_boosted": bracket_expansion(["{,sr__,ttcr__,dycr__}{,2e__,2mu__,emu__}boosted"]),
         "dl_ttcr": ["ttcr", "ttcr__1b", "ttcr__2b", "ttcr__2e", "ttcr__2mu", "ttcr__emu"],
         "dl_dycr": ["dycr", "dycr__1b", "dycr__2b", "dycr__2e", "dycr__2mu", "dycr__emu"],
@@ -345,12 +348,24 @@ def set_config_defaults_and_groups(config_inst):
         "sl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
         "sl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*"],
         "dl": bracket_expansion([
-            "n_{jet,bjet,btag,electron,muon,fatjet,hbbjet,vetotau}",
+            "n_{jet,jet_pt30,bjet,btag,electron,muon,fatjet,hbbjet,vetotau}",
             "lepton{0,1}_{pt,eta,phi,pfreliso,minipfreliso,mvatth}",
             "met_{pt,phi}",
             "jet{0,1,2,3}_{pt,eta,phi,mass,btagpnetb}",
             "bjet{0,1}_{pt,eta,phi,mass,btagpnetb}",
             "ht", "lt", "mll", "ptll", "npvs",
+        ]),
+        "dl_eta_studies": bracket_expansion([
+            "n_{jet,jet_pt30,bjet,btag}",
+            "lepton{0,1}_{pt,eta}",
+            "met_{pt,phi}",
+            "jet{0,1,2}_{pt,eta,phi,mass,btagpnetb}",
+            "bjet{0,1}_{pt,eta,phi,mass,btagpnetb}",
+            "ht", "mll", "ptll",
+            "barreljet{0,1,2}_{pt,eta}",
+            "endcapjet{0,1,2}_{pt,eta}",
+            "barrellep{0,1}_pt",
+            "endcaplep{0,1}_pt",
         ]),
         "dl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht", "lt", "mll", "ptll"],
         "dl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*", "lt", "mll", "ptll"],

--- a/hbw/config/variables.py
+++ b/hbw/config/variables.py
@@ -670,6 +670,18 @@ def add_variables(config: od.Config) -> None:
         ak.fill_none(ak.pad_none(events[obj][abs(events[obj]["eta"]) >= 1.3], i + 1)[field], EMPTY_FLOAT)[:, i]
     )
 
+    dr_expr = lambda events, obj1, i, obj2, j: ak.fill_none(
+        ak.pad_none(events[obj1], i + 1)[:, i].delta_r(ak.pad_none(events[obj2], j + 1)[:, j]), EMPTY_FLOAT,
+    )
+
+    config.add_variable(
+        name="dr_jj",
+        expression=lambda events: dr_expr(events, "Jet", 0, "Jet", 1),
+        aux={"inputs": {"Jet.{pt,eta,phi,mass}"}},
+        binning=(40, 0., 4),
+        x_title=r"$\Delta R(jj)$",
+    )
+
     # Leptons
     config.add_variable(
         name="sum_charge",

--- a/hbw/plotting/s_over_b.py
+++ b/hbw/plotting/s_over_b.py
@@ -13,7 +13,7 @@ import law
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_all import plot_all
 from columnflow.plotting.plot_util import (
-    # prepare_plot_config,
+    # prepare_stack_plot_config,
     prepare_style_config,
     remove_residual_axis,
     apply_variable_settings,

--- a/hbw/production/jets.py
+++ b/hbw/production/jets.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+
+"""
+Column production methods related to higher-level features.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
+
+ak = maybe_import("awkward")
+np = maybe_import("numpy")
+
+# helper functions
+set_ak_bool = partial(set_ak_column, value_type=np.bool_)
+
+
+@producer(
+    uses={"Jet.{pt,eta,phi,mass,jetId,neHEF,neEmEF,muEF,chEmEF}"},
+    produces={"Jet.TightId", "Jet.TightLepVeto"},
+)
+def jetId(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Producer that extracts correct jet ids for Nano v12
+    https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV?rev=21
+    """
+    abseta = abs(events.Jet.eta)
+    print("start")
+    # baseline mask (abseta < 2.7)
+    passJetId_Tight = (events.Jet.jetId & 2 == 2)
+
+    passJetId_Tight = ak.where(
+        (abseta > 2.7) & (abseta <= 3.0),
+        passJetId_Tight & (events.Jet.neHEF < 0.99),
+        passJetId_Tight,
+    )
+    passJetId_Tight = ak.where(
+        abseta > 3.0,
+        passJetId_Tight & (events.Jet.neEmEF < 0.4),
+        passJetId_Tight,
+    )
+
+    passJetId_TightLepVeto = ak.where(
+        abseta <= 2.7,
+        passJetId_Tight & (events.Jet.muEF < 0.8) & (events.Jet.chEmEF < 0.8),
+        passJetId_Tight,
+    )
+
+    events = set_ak_bool(events, "Jet.TightId", passJetId_Tight)
+    events = set_ak_bool(events, "Jet.TightLepVeto", passJetId_TightLepVeto)
+
+    return events
+
+
+@jetId.init
+def jetId_init(self: Producer) -> None:
+    config_inst = getattr(self, "config_inst", None)
+
+    if config_inst and config_inst.campaign.x.version != 12:
+        raise NotImplementedError("jetId Producer only recommended for Nano v12")

--- a/hbw/production/ml_inputs.py
+++ b/hbw/production/ml_inputs.py
@@ -28,11 +28,14 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 ZERO_PADDING_VALUE = -10
 
 
-@producer(uses={"*"}, produces={"dummy"})
+@producer(uses={prepare_objects, "*"}, produces={"dummy"})
 def check_columns(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Check that all columns are present in the events.
     """
+    # apply behavior (for variable reconstruction)
+    events = self[prepare_objects](events, **kwargs)
+
     from hbw.util import debugger
     debugger()
     return events

--- a/hbw/production/normalized_btag.py
+++ b/hbw/production/normalized_btag.py
@@ -81,6 +81,11 @@ def normalized_btag_weights_requires(self: Producer, reqs: dict) -> None:
     reqs["btag_renormalization_sf"] = GetBtagNormalizationSF.req(self.task)
 
 
+normalized_btag_weights_full = normalized_btag_weights.derive("normalized_btag_weights_full", cls_dict=dict(
+    modes=["ht_njet_nhf", "ht_njet", "njet", "ht"],
+))
+
+
 @normalized_btag_weights.setup
 def normalized_btag_weights_setup(self: Producer, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
     # create the corrector

--- a/hbw/production/weights.py
+++ b/hbw/production/weights.py
@@ -63,7 +63,13 @@ def event_weights_to_normalize(self: Producer, events: ak.Array, results: Select
 
     if not has_tag("skip_btag_weights", self.config_inst, self.dataset_inst, operator=any):
         # compute btag SF weights (for renormalization tasks)
-        events = self[btag_weights](events, jet_mask=results.aux["jet_mask"], **kwargs)
+        events = self[btag_weights](
+            events,
+            jet_mask=results.aux["jet_mask"],
+            negative_b_score_action="ignore",
+            negative_b_score_log_mode="debug",
+            **kwargs,
+        )
 
     # skip scale/pdf weights for some datasets (missing columns)
     if not has_tag("skip_scale", self.config_inst, self.dataset_inst, operator=any):
@@ -246,7 +252,12 @@ def event_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     if not has_tag("skip_btag_weights", self.config_inst, self.dataset_inst, operator=any):
         # compute and normalize btag SF weights
-        events = self[btag_weights](events, **kwargs)
+        events = self[btag_weights](
+            events,
+            negative_b_score_action="ignore",
+            negative_b_score_log_mode="debug",
+            **kwargs,
+        )
         events = self[normalized_btag_weights](events, **kwargs)
 
     # compute electron and muon SF weights

--- a/hbw/selection/common.py
+++ b/hbw/selection/common.py
@@ -25,6 +25,7 @@ from columnflow.production.cms.seeds import deterministic_seeds
 
 from hbw.selection.gen import hard_gen_particles
 from hbw.production.weights import event_weights_to_normalize, large_weights_killer
+from hbw.production.prepare_objects import prepare_objects
 from hbw.selection.stats import hbw_selection_step_stats, hbw_increment_stats
 from hbw.selection.hists import hbw_selection_hists
 
@@ -44,7 +45,7 @@ def masked_sorted_indices(mask: ak.Array, sort_var: ak.Array, ascending: bool = 
 
 
 @selector(
-    uses={"*"},
+    uses={prepare_objects, "*"},
     exposed=True,
 )
 def check_columns(
@@ -54,6 +55,8 @@ def check_columns(
     # hists: dict,
     **kwargs,
 ) -> tuple[ak.Array, SelectionResult]:
+    # apply behavior (for variable reconstruction)
+    events = self[prepare_objects](events, **kwargs)
     routes = get_ak_routes(events)  # noqa
     from hbw.util import debugger
     debugger()

--- a/hbw/selection/dl_remastered.py
+++ b/hbw/selection/dl_remastered.py
@@ -211,7 +211,7 @@ from hbw.util import timeit
     # jet selection requirements
     n_jet=None,
     n_btag=None,
-    version=law.config.get_expanded("analysis", "dl1_version", 2),
+    version=law.config.get_expanded("analysis", "dl1_version", 4),
 )
 @timeit
 def dl1(
@@ -250,25 +250,32 @@ def dl1(
 
     results.steps["Resolved"] = (jet_step & bjet_step)
     results.steps["ResolvedOrBoosted"] = (
-        (jet_step & bjet_step | results.steps.HbbJet)
+        ((jet_step & bjet_step) | results.steps.HbbJet)
     )
 
-    # combined event selection after all steps except b-jet selection
-    results.steps["all_but_bjet"] = (
+    results.steps["all_but_trigger_and_bjet"] = (
         results.steps.cleanup &
         results.steps.data_double_counting &
-        (jet_step | results.steps.HbbJet_no_bjet) &
+        jet_step &
         results.steps.ll_lowmass_veto &
         results.steps.TripleLooseLeptonVeto &
         results.steps.Charge &
         results.steps.Dilepton &
-        results.steps.SR &  # exactly 2 tight leptons
+        results.steps.SR  # exactly 2 tight leptons
+    )
+    # combined event selection after all steps except b-jet selection
+    results.steps["all_but_bjet"] = (
+        results.steps.all_but_trigger_and_bjet &
         results.steps.Trigger &
         results.steps.TriggerAndLep
     )
 
     # combined event selection after all steps
     results.steps["all"] = results.event = (
+        results.steps.all_but_bjet &
+        bjet_step
+    )
+    results.steps["all_or_boosted"] = (
         results.steps.all_but_bjet &
         ((jet_step & bjet_step) | results.steps.HbbJet)
     )

--- a/hbw/selection/dl_remastered.py
+++ b/hbw/selection/dl_remastered.py
@@ -5,6 +5,7 @@ Selection modules for HH -> bbWW(lnulnu).
 """
 
 from importlib import import_module
+from functools import partial
 
 from collections import defaultdict
 
@@ -24,6 +25,9 @@ from hbw.production.weights import event_weights_to_normalize
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
+
+# helper functions
+set_ak_bool = partial(set_ak_column, value_type=np.bool_)
 
 
 @selector(
@@ -118,29 +122,21 @@ def dl_lepton_selection(
     # lepton channel masks
     lepton_results.steps["Lep_mm"] = mm_mask = (
         lepton_results.steps.ll_lowmass_veto &
-        # lepton_results.steps.Charge &
-        # lepton_results.steps.TripleLooseLeptonVeto &
         (ak.sum(leading_mu_mask, axis=1) >= 1) &
         (ak.sum(subleading_mu_mask, axis=1) >= 2)
     )
     lepton_results.steps["Lep_ee"] = ee_mask = (
         lepton_results.steps.ll_lowmass_veto &
-        # lepton_results.steps.TripleLooseLeptonVeto &
-        # lepton_results.steps.Charge &
         (ak.sum(leading_e_mask, axis=1) >= 1) &
         (ak.sum(subleading_e_mask, axis=1) >= 2)
     )
     lepton_results.steps["Lep_emu"] = emu_mask = (
         lepton_results.steps.ll_lowmass_veto &
-        # lepton_results.steps.TripleLooseLeptonVeto &
-        # lepton_results.steps.Charge &
         (ak.sum(leading_e_mask, axis=1) >= 1) &
         (ak.sum(subleading_mu_mask, axis=1) >= 1)
     )
     lepton_results.steps["Lep_mue"] = mue_mask = (
         lepton_results.steps.ll_lowmass_veto &
-        # lepton_results.steps.TripleLooseLeptonVeto &
-        # lepton_results.steps.Charge &
         (ak.sum(leading_mu_mask, axis=1) >= 1) &
         (ak.sum(subleading_e_mask, axis=1) >= 1)
     )
@@ -198,6 +194,7 @@ from hbw.util import timeit
 
 
 @selector(
+    produces={"steps.*"},
     exposed=True,
     # configurable attributes
     # object selection requirements
@@ -211,7 +208,7 @@ from hbw.util import timeit
     # jet selection requirements
     n_jet=None,
     n_btag=None,
-    version=law.config.get_expanded("analysis", "dl1_version", 4),
+    version=law.config.get_expanded("analysis", "dl1_version", 5),
 )
 @timeit
 def dl1(
@@ -255,10 +252,9 @@ def dl1(
 
     results.steps["all_but_trigger_and_bjet"] = (
         results.steps.cleanup &
-        results.steps.data_double_counting &
         jet_step &
         results.steps.ll_lowmass_veto &
-        results.steps.TripleLooseLeptonVeto &
+        results.steps.TripleLeptonVeto &
         results.steps.Charge &
         results.steps.Dilepton &
         results.steps.SR  # exactly 2 tight leptons
@@ -266,14 +262,24 @@ def dl1(
     # combined event selection after all steps except b-jet selection
     results.steps["all_but_bjet"] = (
         results.steps.all_but_trigger_and_bjet &
+        results.steps.data_double_counting &
         results.steps.Trigger &
         results.steps.TriggerAndLep
+    )
+    # combined event selection after all steps except trigger
+    results.steps["all_but_trigger"] = (
+        results.steps.all_but_trigger_and_bjet &
+        bjet_step
     )
 
     # combined event selection after all steps
     results.steps["all"] = results.event = (
         results.steps.all_but_bjet &
         bjet_step
+    )
+    results.steps["all_plus_tau_veto"] = (
+        results.steps.all &
+        results.steps.TauVeto
     )
     results.steps["all_or_boosted"] = (
         results.steps.all_but_bjet &
@@ -284,6 +290,16 @@ def dl1(
 
     # build categories
     events, results = self[post_selection](events, results, stats, hists, **kwargs)
+
+    # keep various steps for last-minute selection changes for data/MC debugging
+    keep_steps = (
+        "all", "all_but_trigger", "all_but_bjet", "all_but_trigger_and_bjet",
+        "Trigger", "TriggerAndLep", "data_double_counting",
+        "TripleLooseLeptonVeto", "TripleTightLeptonVeto",
+        "VetoTau",
+    )
+    for step in keep_steps:
+        events = set_ak_bool(events, f"steps.{step}", results.steps[step])
 
     return events, results
 
@@ -310,7 +326,7 @@ def dl1_init(self: Selector) -> None:
         hbw_trigger_selection,
         post_selection,
     }
-    self.produces = {
+    self.produces |= {
         pre_selection,
         vbf_jet_selection, dl_boosted_jet_selection,
         jet_selection, dl_lepton_selection,

--- a/hbw/selection/dl_remastered.py
+++ b/hbw/selection/dl_remastered.py
@@ -277,10 +277,6 @@ def dl1(
         results.steps.all_but_bjet &
         bjet_step
     )
-    results.steps["all_plus_tau_veto"] = (
-        results.steps.all &
-        results.steps.TauVeto
-    )
     results.steps["all_or_boosted"] = (
         results.steps.all_but_bjet &
         ((jet_step & bjet_step) | results.steps.HbbJet)

--- a/hbw/selection/jet.py
+++ b/hbw/selection/jet.py
@@ -58,8 +58,8 @@ def jet_selection(
         (events.Jet.jetId >= 6)  # 1: loose, 2: tight, 4: isolated, 6: tight+isolated
     )
 
-    electron = events.Electron[lepton_results.objects.Electron.LooseElectron]
-    muon = events.Muon[lepton_results.objects.Muon.LooseMuon]
+    electron = events.Electron[lepton_results.objects.Electron.Electron]
+    muon = events.Muon[lepton_results.objects.Muon.Muon]
 
     jet_mask = (
         (events.Jet.pt >= self.jet_pt) &

--- a/hbw/selection/lepton.py
+++ b/hbw/selection/lepton.py
@@ -37,7 +37,7 @@ logger = law.logger.get_logger(__name__)
         "{Electron,Muon,Tau}.{pt,eta,phi,mass}",
         "Electron.{dxy,dz,cutBased}",
         "Muon.{dxy,dz,looseId,pfIsoId}",
-        "Tau.{dz,idDeepTau2017v2p1VSe,idDeepTau2017v2p1VSmu,idDeepTau2017v2p1VSjet,decayMode}",
+        "Tau.{dz,idDeepTau2018v2p5VSe,idDeepTau2018v2p5VSmu,idDeepTau2018v2p5VSjet,decayMode}",
         jet_selection,
     },
     produces={
@@ -126,10 +126,10 @@ def lepton_definition(
     tau_mask_veto = (
         (abs(events.Tau.eta) < 2.3) &
         # (abs(events.Tau.dz) < 0.2) &
-        (events.Tau.pt > 20.0) &
-        (events.Tau.idDeepTau2017v2p1VSe >= 4) &  # 4: VLoose
-        (events.Tau.idDeepTau2017v2p1VSmu >= 8) &  # 8: Tight
-        (events.Tau.idDeepTau2017v2p1VSjet >= 2) &  # 2: VVLoose
+        (events.Tau.pt > 15.0) &
+        (events.Tau.idDeepTau2018v2p5VSe >= 2) &  # VVLoose
+        (events.Tau.idDeepTau2018v2p5VSmu >= 1) &  # VLoose
+        (events.Tau.idDeepTau2018v2p5VSjet >= 5) &  # medium
         (
             (events.Tau.decayMode == 0) |
             (events.Tau.decayMode == 1) |
@@ -138,6 +138,7 @@ def lepton_definition(
             (events.Tau.decayMode == 11)
         )
     )
+    steps["VetoTau"] = ak.sum(tau_mask_veto, axis=1) == 0
 
     # lepton invariant mass cuts
     loose_leptons = ak.concatenate([

--- a/hbw/selection/trigger.py
+++ b/hbw/selection/trigger.py
@@ -35,6 +35,7 @@ logger = law.logger.get_logger(__name__)
     produces={
         # new columns
         "trigger_ids",
+        "trigger_data.any_fired", "trigger_data.HLT*.{all_legs_match,fired,fired_and_all_legs_match}",
     },
 )
 def trigger_selection(
@@ -94,11 +95,6 @@ def trigger_selection(
                     leg_mask = leg_mask & ((events.TrigObj.filterBits & bits) == bits)
             leg_masks.append(index[leg_mask])
 
-            trigger_data = set_ak_bool(
-                trigger_data,
-                f"{trigger.name}.leg_{i}_mask",
-                leg_mask,
-            )
             # at least one object must match this leg
             # NOTE: it could in theory happen, that two legs are matched to the same object.
             # However, as long as the correct trigger bits are required (e.g. 2mu), this
@@ -126,14 +122,15 @@ def trigger_selection(
     # store the fired trigger ids
     trigger_ids = ak.concatenate(trigger_ids, axis=1)
     events = set_ak_int32(events, "trigger_ids", trigger_ids)
+    events = set_ak_bool(events, "trigger_data", trigger_data)
 
     return events, SelectionResult(
         steps={
             "trigger": trigger_data.any_fired,
         },
-        aux={
-            "trigger_data": trigger_data,
-        },
+        # aux={
+        #     "trigger_data": trigger_data,
+        # },
     )
 
 

--- a/hbw/tasks/inspection.py
+++ b/hbw/tasks/inspection.py
@@ -6,8 +6,12 @@ Custom tasks for inspecting the configuration or certain task outputs.
 
 from collections import defaultdict
 
+from functools import cached_property
+
 import law
 import luigi
+
+from scinum import Number
 
 
 from columnflow.tasks.framework.mixins import (
@@ -20,6 +24,7 @@ from columnflow.tasks.reduction import ReducedEventsUser
 from columnflow.tasks.selection import MergeSelectionStats
 from columnflow.util import maybe_import, dev_sandbox
 from columnflow.columnar_util import get_ak_routes, update_ak_array
+from columnflow.tasks.framework.remote import RemoteWorkflow
 
 from hbw.tasks.base import HBWTask, ColumnsBaseTask
 from hbw.util import round_sig
@@ -29,7 +34,7 @@ ak = maybe_import("awkward")
 logger = law.logger.get_logger(__name__)
 
 
-def create_table_from_csv(csv_file_path):
+def create_table_from_csv(csv_file_path, transpose=False, with_header=True):
     import csv
     from tabulate import tabulate
 
@@ -38,12 +43,18 @@ def create_table_from_csv(csv_file_path):
         reader = csv.reader(file)
         data = list(reader)
 
+    # Transpose the data if requested
+    if transpose:
+        data = list(zip(*data))
+
     # Optionally, if you want to use the first row as headers
-    headers = data[0]  # First row as headers
-    table_data = data[1:]  # Rest as table data
+    headers = None
+    if with_header:
+        headers = data[0]  # First row as headers
+        data = data[1:]  # Rest as table data
 
     # Generate the table using tabulate
-    table = tabulate(table_data, headers=headers, tablefmt="grid")
+    table = tabulate(data, headers=headers, tablefmt="grid")
 
     # Print the table
     print(table)
@@ -55,8 +66,13 @@ class SelectionSummary(
     DatasetsProcessesMixin,
     SelectorMixin,
     CalibratorsMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
 ):
-    reqs = Requirements(MergeSelectionStats=MergeSelectionStats)
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
+        MergeSelectionStats=MergeSelectionStats,
+    )
 
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
@@ -65,13 +81,28 @@ class SelectionSummary(
         default=tuple(),
     )
 
-    # @cached_property
-    # def datasets(self):
-    #     return [dataset.name for dataset in self.config_inst.datasets]
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
+        return parts
+
+    def create_branch_map(self):
+        # single branch without payload
+        return {0: None}
 
     def requires(self):
-        print("SelectionSummary requires")
         reqs = {}
+        for dataset in self.datasets:
+            reqs[dataset] = self.reqs.MergeSelectionStats.req(
+                self,
+                dataset=dataset,
+                branch=-1,
+                workflow="local",
+            )
+        return reqs
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         for dataset in self.datasets:
             reqs[dataset] = self.reqs.MergeSelectionStats.req(
                 self,
@@ -84,10 +115,20 @@ class SelectionSummary(
     def keys_repr(self):
         return "_".join(sorted(self.keys_of_interest))
 
+    @cached_property
+    def stats(self):
+        inp = self.input()
+        return {
+            dataset: inp[dataset]["collection"][0]["stats"].load(formatter="json")
+            for dataset in self.datasets
+        }
+
     def output(self):
         output = {
             "selection_summary_csv": self.target("selection_summary.csv"),
             "selection_summary_table": self.target("selection_summary.txt"),
+            "selection_steps_summary_csv": self.target("selection_steps_summary.csv"),
+            "selection_steps_summary_table": self.target("selection_steps_summary.txt"),
         }
         return output
 
@@ -95,7 +136,6 @@ class SelectionSummary(
         import csv
         outp.touch()
         lumi = self.config_inst.x.luminosity
-        inputs = self.input()
 
         empty_datasets = []
 
@@ -113,30 +153,35 @@ class SelectionSummary(
 
             writer.writerow(["Dataset"] + [header_map.get(key, key) for key in keys_of_interest])
             for dataset in self.datasets:
-                stats = inputs[dataset]["collection"][0]["stats"].load(formatter="json")
+                dataset_inst = self.config_inst.get_dataset(dataset)
+                stats = self.stats[dataset]
                 # hists = inputs[dataset]["collection"][0]["hists"].load(formatter="pickle")
 
-                xsec = self.config_inst.get_dataset(dataset).processes.get_first().xsecs.get(
+                xsec = dataset_inst.processes.get_first().xsecs.get(
                     self.config_inst.campaign.ecm, None,
                 )
 
                 def safe_div(num, den):
                     return num / den if den != 0 else 0
 
-                missing_keys = {"sum_mc_weight", "sum_mc_weight_selected"} - set(stats.keys())
+                sumw_key = "sum_mc_weight" if dataset_inst.is_mc else "num_events"
+
+                missing_keys = {f"{sumw_key}", f"{sumw_key}_selected"} - set(stats.keys())
                 if missing_keys:
                     logger.warning(f"Missing keys in stats in dataset {dataset}: {missing_keys}")
                     continue
 
-                selection_eff = safe_div(stats["sum_mc_weight_selected"], stats["sum_mc_weight"])
-                if xsec is not None:
+                selection_eff = safe_div(stats[f"{sumw_key}_selected"], stats[f"{sumw_key}"])
+                if dataset_inst.is_data:
+                    expected_yield = Number(stats["num_events_selected"])
+                elif xsec is not None:
                     expected_yield = xsec * selection_eff * lumi
 
                 if stats["num_events_selected"] == 0:
                     empty_datasets.append(dataset)
 
                 selection_summary = {
-                    "xsec": xsec.nominal,
+                    "xsec": xsec.nominal if xsec else -1,
                     "empty": True if stats["num_events_selected"] == 0 else False,
                     "selection_eff": round_sig(selection_eff, 4),
                     "expected_yield": round_sig(expected_yield.nominal, 4),
@@ -154,12 +199,41 @@ class SelectionSummary(
 
         self.publish_message(f"Empty datasets: {empty_datasets}")
 
+    def write_selection_steps_summary(self, outp):
+        import csv
+        outp.touch()
+
+        with open(outp.path, "w") as f:
+            writer = csv.writer(f)
+
+            steps = [
+                k.replace("num_events_step_", "") for k in self.stats[self.datasets[0]].keys()
+                if "num_events_step_" in k
+            ]
+
+            writer.writerow(["Datasets"] + steps)
+
+            for dataset in self.datasets:
+                dataset_inst = self.config_inst.get_dataset(dataset)
+                stats = self.stats[dataset]
+
+                sumw_key = "num_events" if dataset_inst.is_data else "sum_mc_weight"
+
+                row = [dataset] + [stats.get(f"{sumw_key}_step_{step}", 0) / stats.get(sumw_key, 1.) for step in steps]
+                writer.writerow(row)
+
     def run(self):
         output = self.output()
-        self.write_selection_summary(output["selection_summary_csv"])
 
+        # write overall summary
+        self.write_selection_summary(output["selection_summary_csv"])
         table = create_table_from_csv(output["selection_summary_csv"].path)
         output["selection_summary_table"].dump(table, formatter="text")
+
+        # write step-by-step summary
+        self.write_selection_steps_summary(output["selection_steps_summary_csv"])
+        table = create_table_from_csv(output["selection_steps_summary_csv"].path, transpose=True)
+        output["selection_steps_summary_table"].dump(table, formatter="text")
 
 
 class DumpAnalysisSummary(

--- a/hbw/tasks/plotting.py
+++ b/hbw/tasks/plotting.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, defaultdict
 import law
 import order as od
 
-from columnflow.tasks.framework.base import Requirements, ShiftTask
+from columnflow.tasks.framework.base import Requirements, ShiftTask, ConfigTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin,
     CategoriesMixin, DatasetsProcessesMixin,
@@ -120,6 +120,7 @@ class PlotVariablesMultiWeightProducer(
     SelectorStepsMixin,
     CalibratorsMixin,
     ShiftTask,
+    ConfigTask,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/hbw/tasks/postfit_plots.py
+++ b/hbw/tasks/postfit_plots.py
@@ -112,7 +112,7 @@ mplhep = maybe_import("mplhep")
 
 from columnflow.plotting.plot_all import plot_all
 from columnflow.plotting.plot_util import (
-    prepare_plot_config,
+    prepare_stack_plot_config,
     prepare_style_config,
     apply_process_settings,
 )
@@ -134,7 +134,8 @@ def plot_postfit_shapes(
 ) -> tuple(plt.Figure, tuple(plt.Axes)):
     variable_inst = law.util.make_tuple(variable_insts)[0]
     hists = apply_process_settings(hists, process_settings)
-    plot_config = prepare_plot_config(
+
+    plot_config = prepare_stack_plot_config(
         hists,
         shape_norm=shape_norm,
         hide_errors=hide_errors,

--- a/hbw/tasks/yields.py
+++ b/hbw/tasks/yields.py
@@ -233,12 +233,16 @@ class CustomCreateYieldTable(
                     yields[category_inst].append(value)
 
             if self.ratio:
-                processes.append(od.Process("Ratio", id=-9871, label=f"{self.ratio[0]} / {self.ratio[1]}"))
-                num_idx, den_idxs = [processes.index(self.config_inst.get_process(_p)) for _p in self.ratio]
-                for category_inst in category_insts:
-                    num = yields[category_inst][num_idx]
-                    den = yields[category_inst][den_idxs]
-                    yields[category_inst].append(num / den)
+                missing_for_ratio = set(self.ratio[:2]) - set(p.name for p in processes)
+                if missing_for_ratio:
+                    logger.warning(f"Cannot do ratio, missing requested processes: {', '.join(missing_for_ratio)}")
+                else:
+                    processes.append(od.Process("Ratio", id=-9871, label=f"{self.ratio[0]} / {self.ratio[1]}"))
+                    num_idx, den_idxs = [processes.index(self.config_inst.get_process(_p)) for _p in self.ratio]
+                    for category_inst in category_insts:
+                        num = yields[category_inst][num_idx]
+                        den = yields[category_inst][den_idxs]
+                        yields[category_inst].append(num / den)
 
             # obtain normalizaton factors
             norm_factors = 1

--- a/hbw/tasks/yields.py
+++ b/hbw/tasks/yields.py
@@ -1,0 +1,316 @@
+# coding: utf-8
+
+"""
+Tasks to produce yield tables.
+Taken from columnflow and customized.
+TODO: after merging MultiConfigPlotting, we should propagate the changes back to columnflow
+"""
+
+import math
+from collections import defaultdict, OrderedDict
+
+import law
+import luigi
+import order as od
+from scinum import Number
+
+from columnflow.tasks.framework.base import Requirements, ConfigTask
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, SelectorStepsMixin, ProducersMixin,
+    DatasetsProcessesMixin, CategoriesMixin, WeightProducerMixin,
+)
+from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.histograms import MergeHistograms
+from columnflow.util import dev_sandbox, try_int
+
+from hbw.tasks.base import HBWTask
+
+logger = law.logger.get_logger(__name__)
+
+
+class CustomCreateYieldTable(
+    HBWTask,
+    DatasetsProcessesMixin,
+    CategoriesMixin,
+    WeightProducerMixin,
+    ProducersMixin,
+    # MLModelsMixin,
+    SelectorStepsMixin,
+    CalibratorsMixin,
+    ConfigTask,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
+    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+
+    yields_variable = "mll"
+
+    table_format = luigi.Parameter(
+        default="fancy_grid",
+        significant=False,
+        description="format of the yield table; accepts all formats of the tabulate package; "
+        "default: fancy_grid",
+    )
+    number_format = luigi.Parameter(
+        default="pdg",
+        significant=False,
+        description="rounding format of each number in the yield table; accepts all formats "
+        "understood by scinum.Number.str(), e.g. 'pdg', 'publication', '%.1f' or an integer "
+        "(number of signficant digits); default: pdg",
+    )
+    skip_uncertainties = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, uncertainties are not displayed in the table; default: False",
+    )
+    normalize_yields = luigi.ChoiceParameter(
+        choices=(law.NO_STR, "per_process", "per_category", "all"),
+        default=law.NO_STR,
+        significant=False,
+        description="string parameter to define the normalization of the yields; "
+        "choices: '', per_process, per_category, all; empty default",
+    )
+    output_suffix = luigi.Parameter(
+        default=law.NO_STR,
+        description="Adds a suffix to the output name of the yields table; empty default",
+    )
+    transpose = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="Transpose the yield table; default: False",
+    )
+    ratio = law.CSVParameter(
+        default=("data", "background"),
+        significant=False,
+        description="Ratio of two processes to be calculated and added to the table",
+    )
+
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
+        MergeHistograms=MergeHistograms,
+    )
+
+    # dummy branch map
+    def create_branch_map(self):
+        return [0]
+
+    def requires(self):
+        return {
+            d: self.reqs.MergeHistograms.req(
+                self,
+                dataset=d,
+                variables=(self.yields_variable,),
+                _prefer_cli={"variables"},
+            )
+            for d in self.datasets
+        }
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        reqs["merged_hists"] = [
+            self.reqs.MergeHistograms.req(
+                self,
+                dataset=d,
+                variables=(self.yields_variable,),
+                _exclude={"branches"},
+            )
+            for d in self.datasets
+        ]
+
+        return reqs
+
+    @classmethod
+    def resolve_param_values(cls, params):
+        params = super().resolve_param_values(params)
+
+        if "number_format" in params and try_int(params["number_format"]):
+            # convert 'number_format' in integer if possible
+            params["number_format"] = int(params["number_format"])
+
+        return params
+
+    def output(self):
+        suffix = ""
+        if self.output_suffix and self.output_suffix != law.NO_STR:
+            suffix = f"__{self.output_suffix}"
+
+        return {
+            "table": self.target(f"table__proc_{self.processes_repr}__cat_{self.categories_repr}{suffix}.txt"),
+            "csv": self.target(f"table__proc_{self.processes_repr}__cat_{self.categories_repr}{suffix}.csv"),
+            "yields": self.target(f"yields__proc_{self.processes_repr}__cat_{self.categories_repr}{suffix}.json"),
+        }
+
+    @law.decorator.notify
+    @law.decorator.log
+    def run(self):
+        import hist
+        from tabulate import tabulate
+
+        inputs = self.input()
+        outputs = self.output()
+
+        category_insts = list(map(self.config_inst.get_category, sorted(self.categories)))
+        process_insts = list(map(self.config_inst.get_process, self.processes))
+        sub_process_insts = {
+            proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
+            for proc in process_insts
+        }
+
+        # histogram data per process
+        hists = {}
+
+        with self.publish_step(f"Creating yields for processes {self.processes}, categories {self.categories}"):
+            for dataset, inp in inputs.items():
+                dataset_inst = self.config_inst.get_dataset(dataset)
+
+                # load the histogram of the variable named self.yields_variable
+                h_in = inp["hists"][self.yields_variable].load(formatter="pickle")
+
+                # loop and extract one histogram per process
+                for process_inst in process_insts:
+                    # skip when the dataset is already known to not contain any sub process
+                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                        continue
+
+                    # work on a copy
+                    h = h_in.copy()
+
+                    # axis selections
+                    h = h[{
+                        "process": [
+                            hist.loc(p.id)
+                            for p in sub_process_insts[process_inst]
+                            if p.id in h.axes["process"]
+                        ],
+                    }]
+
+                    # axis reductions
+                    h = h[{"process": sum, "shift": sum, self.yields_variable: sum}]
+
+                    # add the histogram
+                    if process_inst in hists:
+                        hists[process_inst] += h
+                    else:
+                        hists[process_inst] = h
+
+            # there should be hists to plot
+            if not hists:
+                raise Exception("no histograms found to plot")
+
+            # sort hists by process order
+            hists = OrderedDict(
+                (process_inst, hists[process_inst])
+                for process_inst in sorted(hists, key=process_insts.index)
+            )
+
+            yields, processes = defaultdict(list), []
+
+            # read out yields per category and per process
+            for process_inst, h in hists.items():
+                processes.append(process_inst)
+
+                # TODO: ratio
+
+                for category_inst in category_insts:
+                    leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
+
+                    h_cat = h[{"category": [
+                        hist.loc(c.name)
+                        for c in leaf_category_insts
+                        if c.name in h.axes["category"]
+                    ]}]
+                    h_cat = h_cat[{"category": sum}]
+
+                    value = Number(h_cat.value)
+                    if not self.skip_uncertainties:
+                        # set a unique uncertainty name for correct propagation below
+                        value.set_uncertainty(
+                            f"mcstat_{process_inst.name}_{category_inst.name}",
+                            math.sqrt(h_cat.variance),
+                        )
+                    yields[category_inst].append(value)
+
+            if self.ratio:
+                processes.append(od.Process("Ratio", id=-9871, label=f"{self.ratio[0]} / {self.ratio[1]}"))
+                num_idx, den_idxs = [processes.index(self.config_inst.get_process(_p)) for _p in self.ratio]
+                for category_inst in category_insts:
+                    num = yields[category_inst][num_idx]
+                    den = yields[category_inst][den_idxs]
+                    yields[category_inst].append(num / den)
+
+            # obtain normalizaton factors
+            norm_factors = 1
+            if self.normalize_yields == "all":
+                norm_factors = sum(
+                    sum(category_yields)
+                    for category_yields in yields.values()
+                )
+            elif self.normalize_yields == "per_process":
+                norm_factors = [
+                    sum(yields[category][i] for category in yields.keys())
+                    for i in range(len(yields[category_insts[0]]))
+                ]
+            elif self.normalize_yields == "per_category":
+                norm_factors = {
+                    category: sum(category_yields)
+                    for category, category_yields in yields.items()
+                }
+
+            # initialize dicts
+            main_label = "Category" if self.transpose else "Process"
+            yields_str = defaultdict(list, {main_label: [proc.label for proc in processes]})
+            raw_yields = defaultdict(dict, {})
+
+            # apply normalization and format
+            for category, category_yields in yields.items():
+                for i, value in enumerate(category_yields):
+                    # get correct norm factor per category and process
+                    if self.normalize_yields == "per_process":
+                        norm_factor = norm_factors[i]
+                    elif self.normalize_yields == "per_category":
+                        norm_factor = norm_factors[category]
+                    else:
+                        norm_factor = norm_factors
+
+                    raw_yield = (value / norm_factor).nominal
+                    raw_yields[category.name][processes[i].name] = raw_yield
+
+                    # format yields into strings
+                    yield_str = (value / norm_factor).str(
+                        combine_uncs="all",
+                        format=self.number_format,
+                        style="latex" if "latex" in self.table_format else "plain",
+                    )
+                    if "latex" in self.table_format:
+                        yield_str = f"${yield_str}$"
+                    cat_label = category.name.replace("__", " ")
+                    # cat_label = category.label
+                    yields_str[cat_label].append(yield_str)
+
+            # Transposing the table
+            data = [list(yields_str.keys())] + list(zip(*yields_str.values()))
+            if self.transpose:
+                data = list(zip(*data))
+
+            headers = data[0]
+
+            # create, print and save the yield table
+            yield_table = tabulate(data[1:], headers=headers, tablefmt=self.table_format)
+
+            with_grid = True
+            if with_grid and self.table_format == "latex_raw":
+                # identify line breaks and add hlines after every line break
+                yield_table = yield_table.replace("\\\\", "\\\\ \\hline")
+                # TODO: lll -> |l|l|l|, etc.
+            self.publish_message(yield_table)
+
+            outputs["table"].dump(yield_table, formatter="text")
+            outputs["yields"].dump(raw_yields, formatter="json")
+
+            outputs["csv"].touch()
+            with open(outputs["csv"].abspath, "w", newline="") as csvfile:
+                import csv
+                writer = csv.writer(csvfile)
+                writer.writerows(data)

--- a/hbw/util.py
+++ b/hbw/util.py
@@ -380,13 +380,17 @@ def four_vec(
     return outp
 
 
-def bracket_expansion(inputs: list):
+def bracket_expansion(inputs: list, clean_chars: str = "_") -> list:
     """
     Expands a list of strings with bracket notation into all possible combinations.
 
     Example:
     bracket_expansion(["{Jet,Muon}.{pt,eta}", "{Electron,Photon}.{phi}"]) -->
     {"Jet.pt", "Jet.eta", "Muon.pt", "Muon.eta", "Electron.phi", "Photon.phi"}
+
+    :param inputs: list of strings with bracket notation
+    :param clean_chars: characters to remove from the beginning and end of each string (default is "_")
+    :return list: expanded and sorted list of strings
 
     NOTE: similar implementation might be somewhere in columnflow.
     """
@@ -403,7 +407,14 @@ def bracket_expansion(inputs: list):
 
         # Generate all possible combinations and add to the output set
         combinations = itertools.product(*options)
-        outp.update(template.format(*combo) for combo in combinations)
+        expanded = (template.format(*combo) for combo in combinations)
+
+        # Remove specified leading/trailing characters
+        cleaned = (s.strip(clean_chars) for s in expanded)
+        outp.update(cleaned)
+
+    # remove empty string
+    outp.discard("")
 
     return sorted(outp)
 
@@ -663,6 +674,14 @@ def IF_MC(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any | set[
         return self.get()
 
     return self.get() if func.dataset_inst.is_mc else None
+
+
+@deferred_column
+def IF_DATA(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any | set[Any]:
+    if getattr(func, "dataset_inst", None) is None:
+        return self.get()
+
+    return self.get() if func.dataset_inst.is_data else None
 
 
 @deferred_column

--- a/law.cfg
+++ b/law.cfg
@@ -130,13 +130,15 @@ lfn_sources: local_desy_dcache, wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlc
 # cf.SelectEvents__hh*: dummy=0
 # cf.ReduceEvents__hh*: dummy=0
 # DY and W needs more memory due to gen_v_boson Producer
-cf.SelectEvents__dy*: htcondor_memory=3GB
-cf.ReduceEvents__dy*: htcondor_memory=3GB
-cf.SelectEvents__w_lnu*: htcondor_memory=3GB
-cf.ReduceEvents__w_lnu*: htcondor_memory=3GB
+cf.SelectEvents__dy*: htcondor_memory=3.5GB
+cf.ReduceEvents__dy*: htcondor_memory=3.5GB
+cf.SelectEvents__w_lnu*: htcondor_memory=3.5GB
+cf.ReduceEvents__w_lnu*: htcondor_memory=3.5GB
 # default resources for all other datasets
+cf.CalibrateEvents: htcondor_memory=2GB
 cf.SelectEvents: htcondor_memory=2.5GB
 cf.ReduceEvents: htcondor_memory=2.5GB
+cf.*: htcondor_memory=1.5GB
 
 
 [luigi_cf.DummyTask]

--- a/law.cfg
+++ b/law.cfg
@@ -8,7 +8,7 @@ inherit: $CF_BASE/law.cfg
 
 columnflow.tasks.cms.external
 columnflow.tasks.cms.inference
-hbw.tasks.{inspection,campaigns,ml,inference,postfit_plots,plotting,wrapper,union,optimization,corrections}
+hbw.tasks.{inspection,campaigns,ml,inference,postfit_plots,plotting,wrapper,union,optimization,corrections,yields}
 
 
 

--- a/law.cfg
+++ b/law.cfg
@@ -132,11 +132,11 @@ lfn_sources: local_desy_dcache, wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlc
 # DY and W needs more memory due to gen_v_boson Producer
 cf.SelectEvents__dy*: htcondor_memory=3GB
 cf.ReduceEvents__dy*: htcondor_memory=3GB
-cf.SelectEvents__w_lnu: htcondor_memory=3GB
-cf.ReduceEvents__w_lnu: htcondor_memory=3GB
+cf.SelectEvents__w_lnu*: htcondor_memory=3GB
+cf.ReduceEvents__w_lnu*: htcondor_memory=3GB
 # default resources for all other datasets
-cf.SelectEvents: htcondor_memory=2GB
-cf.ReduceEvents: htcondor_memory=2GB
+cf.SelectEvents: htcondor_memory=2.5GB
+cf.ReduceEvents: htcondor_memory=2.5GB
 
 
 [luigi_cf.DummyTask]


### PR DESCRIPTION
This PR:

- adds the Electron Scale and Smearing
- prepares our config for 2023 data
- performs some cleanup in calbrator init's
- adds some more variables for plotting
- performs some minor changes in the selection
    - fixes the veto tau collection (did not select any taus before)
    - implements fixes for the jetId in nano v12 (TODO: nano v13 fixes with correctionlib json)
    - loosen lepton veto (only veto events with 3 tight leptons)
    - store some selection steps as well as trigger ids even after ReduceEvents 
- 3-lepton category (should be empty after selection)
- minor auxiliary config info (e.g. groups)
- add potential Categorizer to WeightProducer to allow last-minute masking of events
- minor details in inspection tasks + custom yield table task (to be ported back to columnflow at some point) for Data/MC ratio and transposing table