### PR TITLE
improve running over JEC/JER systematics

### DIFF
--- a/hbw/analysis/processes.py
+++ b/hbw/analysis/processes.py
@@ -60,7 +60,7 @@ def modify_cmsdb_processes():
         },
         "hf": {
             "name": "hf",
-            "id": 60,
+            "id": 70,
             "label": "(hf)",
             "br": -1,
         },

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -440,7 +440,7 @@ def add_config(
 
     # electron calibrations
     cfg.x.eec = EGammaCorrectionConfig(
-        correction_set=f"EGMScale_Compound_Ele_{cfg.x.cpn_tag}",
+        correction_set=f"EGMScale_Compound_Ele_{cfg.x.cpn_tag}".replace("BPix", "BPIX"),
         value_type="scale",
         uncertainty_type="escale",
         compound=True,
@@ -452,7 +452,7 @@ def add_config(
     #     compound=False,
     # )
     cfg.x.eer = EGammaCorrectionConfig(
-        correction_set=f"EGMSmearAndSyst_ElePTsplit_{cfg.x.cpn_tag}",
+        correction_set=f"EGMSmearAndSyst_ElePTsplit_{cfg.x.cpn_tag}".replace("BPix", "BPIX"),
         value_type="smear",
         uncertainty_type="esmear",
     )

--- a/hbw/config/defaults_and_groups.py
+++ b/hbw/config/defaults_and_groups.py
@@ -475,6 +475,9 @@ def set_config_defaults_and_groups(config_inst):
                 "fontsize": 16,
             },
         },
+        "legend_single_col": {
+            "legend_cfg": {"ncols": 1, "fontsize": 20},
+        },
         "small_legend": {
             "legend_cfg": {"ncols": 2, "fontsize": 16},
         },

--- a/hbw/config/processes.py
+++ b/hbw/config/processes.py
@@ -84,6 +84,30 @@ def configure_hbw_processes(config: od.Config):
     # Set dummy xsec for all processes if missing
     add_dummy_xsecs(config)
 
+    # check that all process ids are unique
+    unique_process_sanity_check(config)
+
+
+def unique_process_sanity_check(config: od.Config):
+    """
+    Helper function to check that all process ids are unique in the config.
+    Raises a ValueError if multiple processes with the same id are found.
+    """
+    from collections import defaultdict
+    proc_map = defaultdict(list)
+    for proc, _, _ in config.walk_processes():
+        proc_map[proc.id].append(proc)
+
+    for proc_id, proc_list in proc_map.items():
+        if len(proc_list) > 1:
+            raise ValueError(
+                f"Multiple processes with the same id {proc_id} found: "
+                f"{', '.join([p.name for p in proc_list])}. "
+                "Please ensure that process ids are unique. Note: you might have to re-run the "
+                "Campaign creation after modifying the processes: \n"
+                f"law run hbw.BuildCampaignSummary --config {config.name} --remove-output 0,a,y",
+            )
+
 
 def set_proc_attr(proc_inst, attr, value):
     if attr in ("id", "name"):

--- a/hbw/config/processes.py
+++ b/hbw/config/processes.py
@@ -97,9 +97,9 @@ def unique_process_sanity_check(config: od.Config):
     (i.e. multiple instances of the same process with different settings).
     """
     from collections import defaultdict
-    proc_map = defaultdict(list)
+    proc_map = defaultdict(set)
     for proc, _, _ in config.walk_processes():
-        proc_map[proc.id].append(proc.name)
+        proc_map[proc.id].add(proc.name)
 
     for proc_id, proc_list in proc_map.items():
         if len(proc_list) > 1:

--- a/hbw/config/processes.py
+++ b/hbw/config/processes.py
@@ -92,17 +92,20 @@ def unique_process_sanity_check(config: od.Config):
     """
     Helper function to check that all process ids are unique in the config.
     Raises a ValueError if multiple processes with the same id are found.
+
+    Note: this sanity check does not check for the uniqueness of process instances
+    (i.e. multiple instances of the same process with different settings).
     """
     from collections import defaultdict
     proc_map = defaultdict(list)
     for proc, _, _ in config.walk_processes():
-        proc_map[proc.id].append(proc)
+        proc_map[proc.id].append(proc.name)
 
     for proc_id, proc_list in proc_map.items():
         if len(proc_list) > 1:
             raise ValueError(
                 f"Multiple processes with the same id {proc_id} found: "
-                f"{', '.join([p.name for p in proc_list])}. "
+                f"{', '.join([proc_name for proc_name in proc_list])}. "
                 "Please ensure that process ids are unique. Note: you might have to re-run the "
                 "Campaign creation after modifying the processes: \n"
                 f"law run hbw.BuildCampaignSummary --config {config.name} --remove-output 0,a,y",

--- a/hbw/inference/constants.py
+++ b/hbw/inference/constants.py
@@ -83,6 +83,8 @@ processes_per_pdf_rate = {
 # mapping for each shape uncertainty, which process is used.
 # If "all" is included, takes all processes except for the ones specified (starting with !)
 processes_per_shape = {
+    "jec_Total": ["all"],
+    "jer": ["all"],
     "btag_hf": ["all"],
     "btag_lf": ["all"],
     "btag_hfstats1_{year}": ["all"],

--- a/hbw/inference/dl.py
+++ b/hbw/inference/dl.py
@@ -103,11 +103,21 @@ shape_systematics = [
     "top_pt",
 ]
 
+jerc_systematics = [
+    "jer",
+    "jec_Total",
+]
+
 # All systematics to be included in the final datacard
 systematics = rate_systematics + shape_systematics
 
-
-hhprocs = lambda hhdecay: [
+hhprocs_ggf = lambda hhdecay: [
+    f"hh_ggf_{hhdecay}_kl0_kt1",
+    f"hh_ggf_{hhdecay}_kl1_kt1",
+    f"hh_ggf_{hhdecay}_kl2p45_kt1",
+    f"hh_ggf_{hhdecay}_kl5_kt1",
+]
+hhprocs_vbf = lambda hhdecay: [
     f"hh_vbf_{hhdecay}_kv1p74_k2v1p37_kl14p4",
     f"hh_vbf_{hhdecay}_kvm0p758_k2v1p44_klm19p3",
     f"hh_vbf_{hhdecay}_kvm0p012_k2v0p03_kl10p2",
@@ -118,11 +128,9 @@ hhprocs = lambda hhdecay: [
     f"hh_vbf_{hhdecay}_kvm1p21_k2v1p94_klm0p94",
     f"hh_vbf_{hhdecay}_kvm1p6_k2v2p72_klm1p36",
     f"hh_vbf_{hhdecay}_kvm1p83_k2v3p57_klm3p39",
-    f"hh_ggf_{hhdecay}_kl0_kt1",
-    f"hh_ggf_{hhdecay}_kl1_kt1",
-    f"hh_ggf_{hhdecay}_kl2p45_kt1",
-    f"hh_ggf_{hhdecay}_kl5_kt1",
 ]
+hhprocs = lambda hhdecay: [*hhprocs_ggf(hhdecay), *hhprocs_vbf(hhdecay)]
+
 backgrounds = [
     # TODO: merge st_schannel, st_tchannel
     "st_tchannel",
@@ -147,6 +155,7 @@ processes_dict = {
     "test": ["tt", *hhprocs("hbb_hww2l2nu")],
     "hww": [*backgrounds, *hhprocs("hbb_hww")],
     "hwwzztt": [*backgrounds, *hhprocs("hbb_hww"), *hhprocs("hbb_hzz"), *hhprocs("hbb_htt")],
+    "hwwzztt_ggf": [*backgrounds, *hhprocs_ggf("hbb_hww"), *hhprocs_ggf("hbb_hzz"), *hhprocs_ggf("hbb_htt")],
 }
 
 default_cls_dict = {
@@ -157,6 +166,7 @@ default_cls_dict = {
     "mc_stats": True,
     "skip_data": True,
 }
+
 
 def config_variable_binary_ggf_and_vbf(self, config_cat_inst):
     """
@@ -233,11 +243,19 @@ weight1_hwwzztt_syst = weight1.derive("weight1_hwwzztt_syst", cls_dict={
     "processes": processes_dict["hwwzztt"],
     "systematics": systematics,
 })
+weight1_hwwzztt_fullsyst = weight1.derive("weight1_hwwzztt_fullsyst", cls_dict={
+    "processes": processes_dict["hwwzztt"],
+    "systematics": systematics + jerc_systematics,
+})
+weight1_hwwzztt_ggf_fullsyst = weight1.derive("weight1_hwwzztt_ggf_fullsyst", cls_dict={
+    "processes": processes_dict["hwwzztt_ggf"],
+    "systematics": systematics + jerc_systematics,
+})
 test = weight1.derive("test", cls_dict={
     "processes": processes_dict["test"],
     "systematics": rate_systematics + ["pdf_shape_tt"],
 })
 test_syst = weight1.derive("test_syst", cls_dict={
     "processes": processes_dict["test"],
-    "systematics": systematics,
+    "systematics": rate_systematics + jerc_systematics,
 })

--- a/hbw/inference/dl.py
+++ b/hbw/inference/dl.py
@@ -15,40 +15,6 @@ from hbw.inference.base import HBWInferenceModelBase
 # used to set default requirements for cf.CreateDatacards based on the config
 ml_model_name = "dl_22post_benchmark"
 
-# All processes to be included in the final datacard
-processes = [
-    "hh_vbf_hbb_hww2l2nu_kv1p74_k2v1p37_kl14p4",
-    "hh_vbf_hbb_hww2l2nu_kvm0p758_k2v1p44_klm19p3",
-    "hh_vbf_hbb_hww2l2nu_kvm0p012_k2v0p03_kl10p2",
-    "hh_vbf_hbb_hww2l2nu_kvm2p12_k2v3p87_klm5p96",
-    "hh_vbf_hbb_hww2l2nu_kv1_k2v1_kl1",
-    "hh_vbf_hbb_hww2l2nu_kv1_k2v0_kl1",
-    "hh_vbf_hbb_hww2l2nu_kvm0p962_k2v0p959_klm1p43",
-    "hh_vbf_hbb_hww2l2nu_kvm1p21_k2v1p94_klm0p94",
-    "hh_vbf_hbb_hww2l2nu_kvm1p6_k2v2p72_klm1p36",
-    "hh_vbf_hbb_hww2l2nu_kvm1p83_k2v3p57_klm3p39",
-    "hh_ggf_hbb_hww2l2nu_kl0_kt1",
-    "hh_ggf_hbb_hww2l2nu_kl1_kt1",
-    "hh_ggf_hbb_hww2l2nu_kl2p45_kt1",
-    "hh_ggf_hbb_hww2l2nu_kl5_kt1",
-    # TODO: merge st_schannel, st_tchannel
-    "st_tchannel",
-    "st_twchannel",
-    # "st_schannel",  # Not datasets anyways
-    "tt",
-    # "ttw",  # TODO: dataset not working?
-    "ttz",
-    "dy",
-    "w_lnu",
-    "vv",
-    "h_ggf", "h_vbf", "zh", "wh", "zh_gg", "tth",
-    # "ttv",  # TODO
-    # "ttvv",  # TODO
-    # "vvv",  # TODO
-    # TODO: add thq, thw, bbh
-    # "qcd",  # probably not needed
-]
-
 # All categories to be included in the final datacard
 config_categories = [
     "sr__1b__ml_sig_ggf",
@@ -140,14 +106,6 @@ shape_systematics = [
 # All systematics to be included in the final datacard
 systematics = rate_systematics + shape_systematics
 
-default_cls_dict = {
-    "ml_model_name": ml_model_name,
-    "processes": processes,
-    "config_categories": config_categories,
-    "systematics": rate_systematics,
-    "mc_stats": True,
-    "skip_data": True,
-}
 
 hhprocs = lambda hhdecay: [
     f"hh_vbf_{hhdecay}_kv1p74_k2v1p37_kl14p4",
@@ -174,7 +132,7 @@ backgrounds = [
     # "ttw",  # TODO: dataset not working?
     "ttz",
     "dy",
-    "w_lnu",
+    # "w_lnu",  # TODO: bogus norm?
     "vv",
     "h_ggf", "h_vbf", "zh", "wh", "zh_gg", "tth",
     # "ttv",  # TODO
@@ -186,10 +144,19 @@ backgrounds = [
 
 processes_dict = {
     "default": [*backgrounds, *hhprocs("hbb_hww2l2nu")],
+    "test": ["tt", *hhprocs("hbb_hww2l2nu")],
     "hww": [*backgrounds, *hhprocs("hbb_hww")],
     "hwwzztt": [*backgrounds, *hhprocs("hbb_hww"), *hhprocs("hbb_hzz"), *hhprocs("hbb_htt")],
 }
 
+default_cls_dict = {
+    "ml_model_name": ml_model_name,
+    "processes": processes_dict["default"],
+    "config_categories": config_categories,
+    "systematics": rate_systematics,
+    "mc_stats": True,
+    "skip_data": True,
+}
 
 def config_variable_binary_ggf_and_vbf(self, config_cat_inst):
     """
@@ -252,10 +219,25 @@ weight1 = dl.derive("weight1", cls_dict={
     "config_variable": config_variable_binary_ggf_and_vbf,
     "systematics": rate_systematics,
 })
+weight1_syst = weight1.derive("weight1_syst", cls_dict={
+    "systematics": systematics,
+})
 
 weight1_hww = weight1.derive("weight1_hww", cls_dict={
     "processes": processes_dict["hww"],
 })
 weight1_hwwzztt = weight1.derive("weight1_hwwzztt", cls_dict={
     "processes": processes_dict["hwwzztt"],
+})
+weight1_hwwzztt_syst = weight1.derive("weight1_hwwzztt_syst", cls_dict={
+    "processes": processes_dict["hwwzztt"],
+    "systematics": systematics,
+})
+test = weight1.derive("test", cls_dict={
+    "processes": processes_dict["test"],
+    "systematics": rate_systematics + ["pdf_shape_tt"],
+})
+test_syst = weight1.derive("test_syst", cls_dict={
+    "processes": processes_dict["test"],
+    "systematics": systematics,
 })

--- a/hbw/ml/base.py
+++ b/hbw/ml/base.py
@@ -36,6 +36,8 @@ class MLClassifierBase(MLModel):
     """
     Provides a base structure to implement Multiclass Classifier in Columnflow
     """
+    # flag denoting whether the preparation_producer is invoked before evaluate()
+    preparation_producer_in_ml_evaluation: bool = False
 
     # set some defaults, can be overwritten by subclasses or via cls_dict
     # NOTE: the order of processes is crucial! Do not change after training

--- a/hbw/ml/derived/dl.py
+++ b/hbw/ml/derived/dl.py
@@ -295,7 +295,7 @@ input_features = {
         "mli_lep2_tag",
         "mli_maxdr_jj",
         "mli_mindr_jj",
-    ]
+    ],
 }
 class_factors = {
     "default": DenseClassifierDL._default__class_factors,

--- a/hbw/ml/derived/dl.py
+++ b/hbw/ml/derived/dl.py
@@ -214,6 +214,88 @@ input_features = {
         for obj in ["lep", "lep2"]
         for var in ["pt", "eta"]
     ],
+    "sorted_previous": [
+        "mli_mbb",
+        "mli_b1_pt",
+        "mli_j1_pt",
+        "mli_n_jet",
+        "mli_mbbllMET",
+        "mli_dr_bb_llMET",
+        "mli_j1_eta",
+        "mli_met_pt",
+        "mli_mllMET",
+        "mli_mll",
+        "mli_ll_pt",
+        "mli_lep_pt",
+        "mli_lep2_pt",
+        "mli_dphi_bb_nu",
+        "mli_j1_b_score",
+        "mli_bb_pt",
+        "mli_dr_ll",
+        "mli_b_score_sum",
+        "mli_min_dr_llbb",
+        "mli_b2_pt",
+        "mli_lep_eta",
+        "mli_b1_eta",
+        "mli_dr_bb",
+        "mli_mindr_lb",
+        "mli_ht",
+        "mli_b2_eta",
+        "mli_b2_b_score",
+        "mli_n_btag",
+        "mli_lep2_eta",
+        "mli_dhpi_bb",
+        "mli_b1_b_score",
+        "mli_dhpi_bb_llMET",
+        "mli_dphi_ll",
+        "mli_vbf_mass",
+        "mli_vbf_tag",
+        "mli_vbf_deta",
+    ],
+    "reduced": [
+        "mli_mbb",
+        "mli_b1_pt",
+        "mli_j1_pt",
+        "mli_n_jet",
+        "mli_mbbllMET",
+        "mli_dr_bb_llMET",
+        "mli_j1_eta",
+        "mli_met_pt",
+        "mli_mllMET",
+        "mli_mll",
+        "mli_ll_pt",
+        "mli_lep_pt",
+        "mli_lep2_pt",
+        "mli_dphi_bb_nu",
+        "mli_j1_b_score",
+        "mli_bb_pt",
+        "mli_dr_ll",
+        "mli_b_score_sum",
+        "mli_min_dr_llbb",
+        "mli_b2_pt",
+        # "mli_lep_eta",
+        # "mli_b1_eta",
+        "mli_dr_bb",
+        "mli_mindr_lb",
+        "mli_ht",
+        # "mli_b2_eta",
+        # "mli_b2_b_score",
+        # "mli_n_btag",
+        # "mli_lep2_eta",
+        # "mli_dhpi_bb",
+        # "mli_b1_b_score",
+        # "mli_dhpi_bb_llMET",
+        # "mli_dphi_ll",
+        "mli_vbf_mass",  # important for vbf?
+        "mli_vbf_tag",  # important for vbf?
+        "mli_vbf_deta",  # important for vbf?
+    ],
+    "new": [
+        "mli_lep_tag",
+        "mli_lep2_tag",
+        "mli_maxdr_jj",
+        "mli_mindr_jj",
+    ]
 }
 class_factors = {
     "default": DenseClassifierDL._default__class_factors,
@@ -243,34 +325,45 @@ dl_22post_benchmark_v3 = DenseClassifierDL.derive("dl_22post_benchmark_v3", cls_
     "class_factors": class_factors["benchmark"],
 })
 # has been run with same setup as v1
-dl_22post_previous = dl_22post.derive("dl_22post_previous", cls_dict={
+dl_22post_previous = DenseClassifierDL.derive("dl_22post_previous", cls_dict={
     "training_configs": lambda self, requested_configs: ["c22post"],
     "class_factors": class_factors["benchmark"],
     "input_features": input_features["previous"],
 })
-dl_22post_weight1 = dl_22post.derive("dl_22post_weight1", cls_dict={
+dl_22post_weight1 = DenseClassifierDL.derive("dl_22post_weight1", cls_dict={
     "training_configs": lambda self, requested_configs: ["c22post"],
     "class_factors": class_factors["ones"],
     "input_features": input_features["previous"],
 })
-dl_22post_previous_merge_hh = dl_22post.derive("dl_22post_previous_merge_hh", cls_dict={
+dl_22post_added = DenseClassifierDL.derive("dl_22post_added", cls_dict={
+    "training_configs": lambda self, requested_configs: ["c22post"],
+    "class_factors": class_factors["ones"],
+    "input_features": input_features["previous"] + input_features["new"],
+})
+dl_22post_reduced = DenseClassifierDL.derive("dl_22post_reduced", cls_dict={
+    "training_configs": lambda self, requested_configs: ["c22post"],
+    "class_factors": class_factors["ones"],
+    "input_features": input_features["reduced"],
+})
+dl_22post_previous_merge_hh = DenseClassifierDL.derive("dl_22post_previous_merge_hh", cls_dict={
     "training_configs": lambda self, requested_configs: ["c22post"],
     "processes": processes["merge_hh"],
     "class_factors": class_factors["benchmark"],
     "input_features": input_features["previous"],
 })
 
-dl_22post_test = dl_22post.derive("dl_22post_test", cls_dict={
+dl_22post_test = DenseClassifierDL.derive("dl_22post_test", cls_dict={
+    "training_configs": lambda self, requested_configs: ["l22post"],
     "processes": ["hh_ggf_hbb_hvv2l2nu_kl1_kt1", "st_tchannel_t"],
     "epochs": 20,
 })
-dl_22post_limited = dl_22post.derive("dl_22post_limited", cls_dict={
+dl_22post_limited = DenseClassifierDL.derive("dl_22post_limited", cls_dict={
     "training_configs": lambda self, requested_configs: ["l22post"],
     "processes": ["hh_ggf_hbb_hvv2l2nu_kl1_kt1", "st_tchannel_t"],
     "epochs": 6,
 })
 
-dl_22post_binary_test3 = dl_22post.derive("dl_22post_binary_test3", cls_dict={
+dl_22post_binary_test3 = DenseClassifierDL.derive("dl_22post_binary_test3", cls_dict={
     "training_configs": lambda self, requested_configs: ["c22post"],
     "processes": [
         "hh_ggf_hbb_hvv2l2nu_kl0_kt1",
@@ -338,7 +431,7 @@ dl_22post_binary_test3 = dl_22post.derive("dl_22post_binary_test3", cls_dict={
     },
     "epochs": 100,
 })
-dl_22post_vbf = dl_22post.derive("dl_22post_vbf", cls_dict={
+dl_22post_vbf = DenseClassifierDL.derive("dl_22post_vbf", cls_dict={
     "training_configs": lambda self, requested_configs: ["c22post"],
     "processes": [
         "hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1",

--- a/hbw/production/normalized_weights.py
+++ b/hbw/production/normalized_weights.py
@@ -71,14 +71,17 @@ def normalized_weight_factory(
 
         return events
 
-    @normalized_weight.init
-    def normalized_weight_init(self: Producer) -> None:
+    @normalized_weight.post_init
+    def normalized_weight_post_init(self: Producer, task: law.Task) -> None:
         self.weight_producers = weight_producers
 
         # resolve weight names
         self.weight_names = set()
         for col in self.used_columns:
             col = col.string_nano_column
+            if task.shift != "nominal" and (col.endswith("_up") or col.endswith("_down")):
+                # skip the up/down variations
+                continue
             if "weight" in col and "normalized" not in col and "btag" not in col:
                 self.weight_names.add(col)
 


### PR DESCRIPTION
This PR reconfigures some Producers/Reducers to store certain columns (e.g. `pdf_weight_up`) only when running on nominal shift.
This might still not be 100% efficient, because we still create columns in-memory, but this effect is probably negligible.

Here are some [plots on limited stats with varied JEC/JER](https://hh2bbww.web.cern.ch/hbw_store/hbw_dl/calib__ak4V2__fatjetV2__eleV2/sel__test_dlV0/red__default/?depth=7)

There's also some more DNN/Inference configuration, which I'll clean up at some point.

**ToDo:**

- [x] Include JEC/JER in datacards