### PR TITLE
Trigger scale factors and single lepton channel

### DIFF
--- a/hbw/analysis/processes.py
+++ b/hbw/analysis/processes.py
@@ -51,6 +51,14 @@ def modify_cmsdb_processes():
         color=color_palette["blue"],
     )
 
+    tt_dy = create_parent_process(  # noqa: F841
+        [tt, dy],
+        name="tt_dy",
+        id=99890206,
+        label="tt + DY",
+        color=color_palette["red"],
+    )
+
     decay_map = {
         "lf": {
             "name": "lf",

--- a/hbw/categorization/categories.py
+++ b/hbw/categorization/categories.py
@@ -181,13 +181,13 @@ def catid_fake(
 
 @categorizer(uses={MET_COLUMN("pt")})
 def catid_highmet(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
-    mask = events[self.config_inst.x.met_name].pt >= 20
+    mask = events[self.config_inst.x.met_name]["pt"] >= 20
     return events, mask
 
 
 @categorizer(uses={MET_COLUMN("pt")})
 def catid_lowmet(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
-    mask = events[self.config_inst.x.met_name].pt < 20
+    mask = events[self.config_inst.x.met_name]["pt"] < 20
     return events, mask
 
 #

--- a/hbw/categorization/categories.py
+++ b/hbw/categorization/categories.py
@@ -294,7 +294,7 @@ ml_processes = [
     "hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1",
     "hh_ggf_hbb_hvvqqlnu_kl1_kt1", "hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
     "hh_ggf_hbb_hvv2l2nu_kl1_kt1", "hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1",
-    "tt", "st", "w_lnu", "dy", "v_lep", "h",
+    "tt", "st", "w_lnu", "dy", "v_lep", "h", "qcd",
     "dy_m50toinf", "tt_dl", "st_tchannel_t",
     "bkg_binary", "sig_ggf_binary", "sig_vbf_binary",
     "sig_ggf", "sig_vbf",

--- a/hbw/config/categories.py
+++ b/hbw/config/categories.py
@@ -91,13 +91,13 @@ def add_abcd_categories(config: od.Config) -> None:
         name="highmet",
         id=3,
         selection="catid_highmet",
-        label=r"$MET \geq 20$",
+        label=r"$MET \geq 20$GeV",
     )
     config.add_category(
         name="lowmet",
         id=6,
         selection="catid_lowmet",
-        label=r"$MET < 20$",
+        label=r"$MET < 20$GeV",
     )
 
 
@@ -111,25 +111,25 @@ def add_mll_categories(config: od.Config) -> None:
         name="sr",
         id=1,
         selection="catid_mll_low",
-        label=r"$m_{\ell\ell} < 81$",
+        label=r"$m_{\ell\ell} < 81$GeV",
     )
     cr = config.add_category(
         name="cr",
         id=2,
         selection="catid_cr",
-        label=r"$m_{\ell\ell} \geq 81$",
+        label=r"$m_{\ell\ell} \geq 81$GeV",
     )
     cr.add_category(
         name="dycr",
         id=3,
         selection="catid_mll_z",
-        label=r"$81 \leq m_{\ell\ell} < 101$",
+        label=r"$81 \leq m_{\ell\ell} < 101$GeV",
     )
     cr.add_category(
         name="ttcr",
         id=4,
         selection="catid_mll_high",
-        label=r"$m_{\ell\ell} \geq 101$",
+        label=r"$m_{\ell\ell} \geq 101$GeV",
     )
 
 

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -22,6 +22,7 @@ from hbw.config.variables import add_variables
 from hbw.config.datasets import add_hbw_processes_and_datasets, configure_hbw_datasets
 from hbw.config.processes import configure_hbw_processes
 from hbw.config.defaults_and_groups import set_config_defaults_and_groups
+from hbw.config.sl_defaults_and_groups import set_sl_config_defaults_and_groups
 from hbw.config.hist_hooks import add_hist_hooks
 from hbw.util import timeit_multiple
 from columnflow.production.cms.dy import DrellYanConfig
@@ -914,7 +915,10 @@ def add_config(
 
     # set some config defaults and groups
     # TODO: it might make sense to completely separate this for SL/DL
-    set_config_defaults_and_groups(cfg)
+    if cfg.has_tag("is_sl"):
+        set_sl_config_defaults_and_groups(cfg)
+    elif cfg.has_tag("is_dl"):
+        set_config_defaults_and_groups(cfg)
 
     # only produce cutflow features when number of dataset_files is limited (used in selection module)
     cfg.x.do_cutflow_features = bool(limit_dataset_files) and limit_dataset_files <= 10
@@ -929,6 +933,10 @@ def add_config(
     if cfg.has_tag("is_sl") and cfg.has_tag("is_resonant"):
         from hbw.config.sl_res import configure_sl_res
         configure_sl_res(cfg)
+
+    # add configuration changes for scale factor calculations
+    # from hbw.config.scale_factors import configure_for_scale_factors
+    # configure_for_scale_factors(cfg)
 
     # sanity check: sometimes the process is not the same as the one in the dataset
     p1 = cfg.get_process("dy_m50toinf")

--- a/hbw/config/config_run2.py
+++ b/hbw/config/config_run2.py
@@ -24,6 +24,7 @@ from hbw.config.processes import configure_hbw_processes
 from hbw.config.defaults_and_groups import set_config_defaults_and_groups
 from hbw.config.sl_defaults_and_groups import set_sl_config_defaults_and_groups
 from hbw.config.hist_hooks import add_hist_hooks
+from hbw.config.scale_factors import configure_for_scale_factors
 from hbw.util import timeit_multiple
 from columnflow.production.cms.dy import DrellYanConfig
 
@@ -101,6 +102,9 @@ def add_config(
         return (values or []) if match else []
 
     cfg.x.if_era = if_era
+
+    # add tag if used for scale factor calculation
+    # cfg.add_tag("is_for_sf")
 
     # add some important tags to the config
     # TODO: generalize and move to campaign
@@ -935,8 +939,8 @@ def add_config(
         configure_sl_res(cfg)
 
     # add configuration changes for scale factor calculations
-    # from hbw.config.scale_factors import configure_for_scale_factors
-    # configure_for_scale_factors(cfg)
+    if cfg.has_tag("is_for_sf"):
+        configure_for_scale_factors(cfg)
 
     # sanity check: sometimes the process is not the same as the one in the dataset
     p1 = cfg.get_process("dy_m50toinf")

--- a/hbw/config/datasets.py
+++ b/hbw/config/datasets.py
@@ -43,6 +43,20 @@ def hbw_dataset_names(config: od.Config, as_list: bool = False) -> DotDict[str: 
         for stream in config.x.data_streams
     ]
 
+    # Add additional datasets needed for orthogonal efficiency measurements.
+    if config.has_tag("is_for_sf"):
+        data_jethtmet_eras = {
+            "2022preEE": "cd",
+            "2022postEE": "efg",
+            "2023preBPix": "",
+            "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
+        }[config.x.cpn_tag]
+
+        data_jethtmet_datasets = [
+            f"data_jethtmet_{era}"
+            for era in data_jethtmet_eras
+        ]
+
     ggf_samples = lambda hhdecay: [
         f"hh_ggf_{hhdecay}_kl0_kt1_powheg",
         f"hh_ggf_{hhdecay}_kl1_kt1_powheg",
@@ -73,6 +87,7 @@ def hbw_dataset_names(config: od.Config, as_list: bool = False) -> DotDict[str: 
     dataset_names = DotDict.wrap({
         # **data_datasets,
         "data": data_datasets,
+        "data_jethtmet": config.x.if_era(cfg_tag="is_for_sf", values=data_jethtmet_datasets),
         "tt": ["tt_sl_powheg", "tt_dl_powheg", "tt_fh_powheg"],
         "st": [
             # "st_schannel_lep_4f_amcatnlo",

--- a/hbw/config/datasets.py
+++ b/hbw/config/datasets.py
@@ -44,18 +44,17 @@ def hbw_dataset_names(config: od.Config, as_list: bool = False) -> DotDict[str: 
     ]
 
     # Add additional datasets needed for orthogonal efficiency measurements.
-    if config.has_tag("is_for_sf"):
-        data_jethtmet_eras = {
-            "2022preEE": "cd",
-            "2022postEE": "efg",
-            "2023preBPix": "",
-            "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
-        }[config.x.cpn_tag]
+    data_jethtmet_eras = {
+        "2022preEE": "cd",
+        "2022postEE": "efg",
+        "2023preBPix": "",
+        "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
+    }[config.x.cpn_tag]
 
-        data_jethtmet_datasets = [
-            f"data_jethtmet_{era}"
-            for era in data_jethtmet_eras
-        ]
+    data_jethtmet_datasets = [
+        f"data_jethtmet_{era}"
+        for era in data_jethtmet_eras
+    ]
 
     ggf_samples = lambda hhdecay: [
         f"hh_ggf_{hhdecay}_kl0_kt1_powheg",

--- a/hbw/config/scale_factors.py
+++ b/hbw/config/scale_factors.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+
+"""
+Contains changes to the config needed for the calculation of trigger efficiencies and scale factors.
+"""
+
+
+import order as od
+
+
+from hbw.util import call_once_on_config
+
+
+@call_once_on_config
+def configure_for_scale_factors(cfg: od.Config) -> None:
+    """
+    TODO: Document changes this function does to the config.
+    """
+
+    ####################################################################################################################
+    # Changes for single lepton channel
+    ####################################################################################################################
+    if cfg.has_tag("is_sl") and cfg.has_tag("is_nonresonant"):
+        # Set list of trigger paths to explore, this is only needed for triggers not fully added in the trigger config.
+        # Single lepton triggers for non-resonant searches
+        cfg.x.sl_triggers = {}
+        cfg.x.sl_triggers["2022"] = {
+            "e": [
+                "Ele30_WPTight_Gsf",
+                "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65",
+                "Ele28_eta2p1_WPTight_Gsf_HT150",
+                "Ele15_IsoVVVL_PFHT450",
+                "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            ],
+            "m": [
+                "IsoMu24",
+                "Mu50",
+                "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65",
+                "Mu15_IsoVVVL_PFHT450",
+            ],
+        }
+        cfg.x.sl_triggers["2023"] = {
+            "e": [
+                "Ele30_WPTight_Gsf",
+                "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+                "Ele28_eta2p1_WPTight_Gsf_HT150",
+                "Ele15_IsoVVVL_PFHT450",
+                "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+                "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            ],
+            "m": [
+                "IsoMu24",
+                "Mu50",
+                "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+                "Mu15_IsoVVVL_PFHT450",
+                "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+                "Mu3er1p5_PFJet100er2p5_PFMETNoMu100_PFMHTNoMu100_IDTight",
+            ],
+        }
+        # cfg.x.sl_orthogonal_triggers = {}
+
+        # Add paths to keep after ReduceEvents
+        for channel in cfg.x.sl_triggers[cfg.x.cpn_tag[:4]]:
+            for path in cfg.x.sl_triggers[cfg.x.cpn_tag[:4]][channel]:
+                if f"HLT.{path}" not in cfg.x.keep_columns["cf.ReduceEvents"]:
+                    cfg.x.keep_columns["cf.ReduceEvents"] |= {f"HLT.{path}"}
+
+    ####################################################################################################################
+    # Changes for dilepton channel
+    ####################################################################################################################
+    if cfg.has_tag("is_dl") and cfg.has_tag("is_nonresonant"):
+        # Double lepton triggers for non-resonant searches, only the orthgonal trigger needs to be set here
+        # TODO: At some point this should probably time dependent as well
+        cfg.x.dl_orthogonal_trigger = "PFMETNoMu120_PFMHTNoMu120_IDTight"
+        cfg.x.hlt_L1_seeds = {
+            "PFMETNoMu120_PFMHTNoMu120_IDTight": [
+                "ETMHF90",
+                "ETMHF100",
+                "ETMHF110",
+                "ETMHF120",
+                "ETMHF130",
+                "ETMHF140",
+                "ETMHF150",
+                "ETM150",
+                "ETMHF90_SingleJet60er2p5_dPhi_Min2p1",
+                "ETMHF90_SingleJet60er2p5_dPhi_Min2p6",
+            ],
+        }
+        # Add paths to keep after ReduceEvents
+        cfg.x.keep_columns["cf.ReduceEvents"] |= {f"HLT.{cfg.x.dl_orthogonal_trigger}"}
+        for seed in cfg.x.hlt_L1_seeds[cfg.x.dl_orthogonal_trigger]:
+            if f"L1.{seed}" not in cfg.x.keep_columns["cf.ReduceEvents"]:
+                cfg.x.keep_columns["cf.ReduceEvents"] |= {f"L1.{seed}"}
+
+        # Add additional datasets needed for orthogonal efficiency measurements.
+        data_jethtmet_eras = {
+            "2022preEE": "cd",
+            "2022postEE": "efg",
+            "2023preBPix": "",
+            "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
+        }[cfg.x.cpn_tag]
+
+        data_jethtmet_datasets = [
+            f"data_jethtmet_{era}"
+            for era in data_jethtmet_eras
+        ]
+
+        cfg.x.dataset_names.update({"data_jethtmet": data_jethtmet_datasets})
+        cfg.add_process(cfg.x.procs.n.data_jethtmet)
+        for dataset in data_jethtmet_datasets:
+            cfg.add_dataset(cfg.campaign.get_dataset(dataset))
+            if cfg.x.cpn_tag == "2022preEE":
+                cfg.datasets.get(dataset).x.jec_era = "RunCD"
+
+        #
+        # Collection of smaller changes
+        #
+        # use histproducer without trigger scale factors
+        cfg.x.default_hist_producer = "default"
+
+        # add combined process with ttbar and drell-yan
+        cfg.add_process(cfg.x.procs.n.tt_dy)
+
+        # Change variables
+        # need npvs as floats in the scale factor calculation
+        cfg.variables.remove("npvs")
+        cfg.add_variable(
+            name="npvs",
+            expression=lambda events: events.PV.npvs * 1.0,
+            aux={
+                "inputs": {"PV.npvs"},
+            },
+            binning=(81, 0, 81),
+            x_title="Number of primary vertices",
+            discrete_x=True,
+        )
+        # change lepton pt binning
+        for i in [0, 1]:
+            cfg.variables.get(f"lepton{i}_pt").binning = (240, 0., 240.)
+        # add trigger ids as variables
+        cfg.add_variable(
+            name="trigger_ids",  # these are the trigger IDs saved during the selection
+            aux={"axis_type": "intcat"},
+            x_title="Trigger IDs",
+        )
+        # trigger ids für scale factors
+        cfg.add_variable(
+            name="trig_ids",  # these are produced in the trigger_prod producer when building different combinations
+            aux={"axis_type": "strcat"},
+            x_title="Trigger IDs for scale factors",
+        )
+
+    ####################################################################################################################
+    # Changes for both channels
+    ####################################################################################################################
+    # change process scale for signal processes
+    for proc, _, _ in cfg.walk_processes():
+        # unstack signal in plotting
+        if "hh_" in proc.name.lower():
+            proc.add_tag("is_signal")
+            proc.unstack = True
+            proc.scale = None

--- a/hbw/config/scale_factors.py
+++ b/hbw/config/scale_factors.py
@@ -93,24 +93,24 @@ def configure_for_scale_factors(cfg: od.Config) -> None:
                 cfg.x.keep_columns["cf.ReduceEvents"] |= {f"L1.{seed}"}
 
         # Add additional datasets needed for orthogonal efficiency measurements.
-        data_jethtmet_eras = {
-            "2022preEE": "cd",
-            "2022postEE": "efg",
-            "2023preBPix": "",
-            "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
-        }[cfg.x.cpn_tag]
+        # data_jethtmet_eras = {
+        #     "2022preEE": "cd",
+        #     "2022postEE": "efg",
+        #     "2023preBPix": "",
+        #     "2023postBPix": "",  # TODO: add 2023 jetmet datasets in cmsdb
+        # }[cfg.x.cpn_tag]
 
-        data_jethtmet_datasets = [
-            f"data_jethtmet_{era}"
-            for era in data_jethtmet_eras
-        ]
+        # data_jethtmet_datasets = [
+        #     f"data_jethtmet_{era}"
+        #     for era in data_jethtmet_eras
+        # ]
 
-        cfg.x.dataset_names.update({"data_jethtmet": data_jethtmet_datasets})
-        cfg.add_process(cfg.x.procs.n.data_jethtmet)
-        for dataset in data_jethtmet_datasets:
-            cfg.add_dataset(cfg.campaign.get_dataset(dataset))
-            if cfg.x.cpn_tag == "2022preEE":
-                cfg.datasets.get(dataset).x.jec_era = "RunCD"
+        # cfg.x.dataset_names.update({"data_jethtmet": data_jethtmet_datasets})
+        # cfg.add_process(cfg.x.procs.n.data_jethtmet)
+        # for dataset in data_jethtmet_datasets:
+        #     cfg.add_dataset(cfg.campaign.get_dataset(dataset))
+        #     if cfg.x.cpn_tag == "2022preEE":
+        #         cfg.datasets.get(dataset).x.jec_era = "RunCD"
 
         #
         # Collection of smaller changes

--- a/hbw/config/sl/__init__.py
+++ b/hbw/config/sl/__init__.py
@@ -12,5 +12,10 @@ import order as od
 
 
 def configure_sl(config: od.Config):
-    # dummy function for now
+    """
+    Configure the SL-specific settings of the HH -> bbWW analysis.
+    """
+
+    # add qcd as process
+    config.add_process(config.x.procs.n.qcd)
     return

--- a/hbw/config/sl_defaults_and_groups.py
+++ b/hbw/config/sl_defaults_and_groups.py
@@ -1,0 +1,473 @@
+# coding: utf-8
+
+import law
+
+from columnflow.inference import InferenceModel
+from columnflow.tasks.framework.base import RESOLVE_DEFAULT
+from hbw.util import bracket_expansion
+
+
+def default_calibrator(container):
+    # return ["with_b_reg", "fatjet"]
+    return ["ak4", "fatjet", "ele"]
+
+
+def default_selector(container):
+    if container.has_tag("is_sl"):
+        selector = "sl1"
+    elif container.has_tag("is_dl"):
+        selector = "dl1"
+
+    return selector
+
+
+def ml_inputs_producer(container):
+    if container.has_tag("is_sl") and not container.has_tag("is_resonant"):
+        ml_inputs = "sl_ml_inputs"
+    if container.has_tag("is_dl"):
+        ml_inputs = "dl_ml_inputs"
+    if container.has_tag("is_sl") and container.has_tag("is_resonant"):
+        ml_inputs = "sl_res_ml_inputs"
+    return ml_inputs
+
+
+def default_ml_model(cls, container, task_params):
+    """ Function that chooses the default_ml_model based on the inference_model if given """
+    # for most tasks, do not use any default ml model
+    default_ml_model = ()
+
+    # set default ml_model when task is part of the MLTraining pipeline
+    # NOTE: default_ml_model does not work for the MLTraining task
+    if hasattr(cls, "ml_model"):
+        # TODO: we might want to distinguish between multiple default ML models (sl vs dl)
+        default_ml_model = "dense_default"
+
+    # check if task is using an inference model
+    # if that is the case, use the default ml_model set in the inference model
+    if getattr(cls, "inference_model", None):
+        inference_model = task_params.get("inference_model", None)
+
+        # if inference model is not set, assume it's the container default
+        if inference_model in (None, law.NO_STR, RESOLVE_DEFAULT):
+            inference_model = container.x.default_inference_model
+
+        # get the default_ml_model from the inference_model_cls
+        inference_model_cls = InferenceModel.get_cls(inference_model)
+        default_ml_model = getattr(inference_model_cls, "ml_model_name", default_ml_model)
+
+    return default_ml_model
+
+
+def default_producers(cls, container, task_params):
+    """ Default producers chosen based on the Inference model and the ML Model """
+
+    # per default, use the ml_inputs and event_weights
+    default_producers = ["event_weights", "pre_ml_cats", ml_inputs_producer(container)]
+
+    if hasattr(cls, "ml_model"):
+        # do no further resolve the ML categorizer when this task is part of the MLTraining pipeline
+        default_producers.remove("pre_ml_cats")
+        return default_producers
+
+    # check if a mlmodel has been set
+    ml_model = task_params.get("ml_models", None)
+
+    # only consider 1 ml_model
+    if ml_model and isinstance(ml_model, (list, tuple)):
+        ml_model = ml_model[0]
+
+    # try and get the default ml model if not set
+    if ml_model in (None, law.NO_STR, RESOLVE_DEFAULT):
+        ml_model = default_ml_model(cls, container, task_params)
+
+    # if a ML model is set, and the task is not part of the MLTraining pipeline,
+    # use the ml categorization producer instead of the default categorization producer
+    if ml_model not in (None, law.NO_STR, RESOLVE_DEFAULT, tuple()):
+        default_producers.remove("pre_ml_cats")
+        # NOTE: this producer needs to be added as the last element! otherwise, category_ids will be overwritten
+        default_producers.append(f"cats_ml_{ml_model}")
+
+    return default_producers
+
+
+def set_sl_config_defaults_and_groups(config_inst):
+    """ Configuration function that sets all the defaults and groups in the config_inst """
+    year = config_inst.campaign.x.year
+
+    # define the default dataset and process based on the analysis tags
+    signal_tag = "qqlnu" if config_inst.has_tag("is_sl") else "2l2nu"
+    default_signal_process = "hh_ggf_hbb_hvv_kl1_kt1"
+    signal_generator = "powheg"
+
+    if config_inst.has_tag("resonant"):
+        signal_tag = f"res_{signal_tag}"
+        # for resonant, rely on the law.cfg to define the default signal process (NOTE: might change in the future)
+        default_signal_process = law.config.get_expanded("analysis", "default_dataset")
+        signal_generator = "madgraph"
+
+    #
+    # Defaults
+    #
+
+    # TODO: the default dataset is currently still being set up by the law.cfg
+    config_inst.x.default_dataset = default_signal_dataset = f"{default_signal_process}_{signal_generator}"
+    config_inst.x.default_calibrator = default_calibrator(config_inst)
+    config_inst.x.default_selector = default_selector(config_inst)
+    config_inst.x.default_reducer = "default"
+    config_inst.x.ml_inputs_producer = ml_inputs_producer(config_inst)
+    config_inst.x.default_producer = default_producers
+    config_inst.x.default_hist_producer = "default"
+    # config_inst.x.default_hist_producer = "with_trigger_weight"
+    config_inst.x.default_ml_model = default_ml_model
+    config_inst.x.default_inference_model = "default" if year == 2017 else "sl_22"
+    config_inst.x.default_categories = ["incl", "sr", "dycr", "ttcr"]
+    config_inst.x.default_variables = ["jet0_pt", "mll", "n_jet", "ptll", "lepton0_pt", "lepton1_pt"]
+
+    # general_settings default needs to be tuple (or dict) to be resolved correctly
+    config_inst.x.default_general_settings = ("data_mc_plots",)
+    config_inst.x.default_custom_style_config = "default"
+
+    #
+    # Groups
+    #
+
+    backgrounds0 = ["h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"]
+    backgrounds1 = ["h", "ttv", "vv", "w_lnu", "st", "dy", "tt"]
+    hbbhww_sm = ["hh_ggf_hbb_hww_kl1_kt1", "hh_vbf_hbb_hww_kv1_k2v1_kl1"]
+    hh_sm = [
+        "hh_ggf_hbb_hww_kl1_kt1", "hh_vbf_hbb_hww_kv1_k2v1_kl1", "hh_ggf_hbb_hzz_kl1_kt1", "hh_ggf_hbb_htt_kl1_kt1",
+    ]
+
+    # process groups for conveniently looping over certain processs
+    # (used in wrapper_factory and during plotting)
+    config_inst.x.process_groups = {
+        # Collection of VBF samples with most shape and rate difference
+        "gen_vbf": [
+            "hh_vbf_hbb_hww2l2nu_kvm0p758_k2v1p44_klm19p3",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v1_kl1",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v0_kl1",
+            "hh_vbf_hbb_hww2l2nu_kvm0p962_k2v0p959_klm1p43",
+        ],
+        "ml_study": [
+            "hh_vbf_hbb_hww2l2nu_kv1p74_k2v1p37_kl14p4",
+            "hh_vbf_hbb_hww2l2nu_kvm0p758_k2v1p44_klm19p3",
+            "hh_vbf_hbb_hww2l2nu_kvm0p012_k2v0p03_kl10p2",
+            "hh_vbf_hbb_hww2l2nu_kvm2p12_k2v3p87_klm5p96",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v1_kl1",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v0_kl1",
+            "hh_vbf_hbb_hww2l2nu_kvm0p962_k2v0p959_klm1p43",
+            "hh_vbf_hbb_hww2l2nu_kvm1p21_k2v1p94_klm0p94",
+            "hh_vbf_hbb_hww2l2nu_kvm1p6_k2v2p72_klm1p36",
+            "hh_vbf_hbb_hww2l2nu_kvm1p83_k2v3p57_klm3p39",
+            "hh_ggf_hbb_hww2l2nu_kl0_kt1",
+            "hh_ggf_hbb_hww2l2nu_kl1_kt1",
+            "hh_ggf_hbb_hww2l2nu_kl2p45_kt1",
+            "hh_ggf_hbb_hww2l2nu_kl5_kt1",
+            "st",
+            "tt",
+            "dy_m4to10", "dy_m10to50", "dy_m50toinf",
+            "w_lnu",
+            "vv",
+            "h_ggf", "h_vbf", "zh", "wh", "zh_gg", "tth",
+        ],
+        # Collection of all VBF samples present
+        "vbf_only": [
+            "hh_vbf_hbb_hww2l2nu_kv1p74_k2v1p37_kl14p4",
+            "hh_vbf_hbb_hww2l2nu_kvm0p758_k2v1p44_klm19p3",
+            "hh_vbf_hbb_hww2l2nu_kvm0p012_k2v0p03_kl10p2",
+            "hh_vbf_hbb_hww2l2nu_kvm2p12_k2v3p87_klm5p96",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v1_kl1",
+            "hh_vbf_hbb_hww2l2nu_kv1_k2v0_kl1",
+            "hh_vbf_hbb_hww2l2nu_kvm0p962_k2v0p959_klm1p43",
+            "hh_vbf_hbb_hww2l2nu_kvm1p21_k2v1p94_klm0p94",
+            "hh_vbf_hbb_hww2l2nu_kvm1p6_k2v2p72_klm1p36",
+            "hh_vbf_hbb_hww2l2nu_kvm1p83_k2v3p57_klm3p39",
+        ],
+        "all": ["*"],
+        "default": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "st", "dy", "tt"],  # noqa: E501
+        "sl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "dy", "st", "qcd", "tt"],  # noqa: E501
+        "dl": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1", "h", "vv", "w_lnu", "st", "dy", "tt"],  # noqa: E501
+        "dl1": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy", "tt"],
+        "dl2": [*hbbhww_sm, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dl3": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dlmu": ["data_mu", default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dleg": ["data_egamma", default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "dlmajor": [default_signal_process, "st", "dy", "tt"],
+        "2much": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "2ech": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "emuch": [default_signal_process, "h", "ttv", "vv", "w_lnu", "st", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "tt"],  # noqa: E501
+        "inference": ["hh_ggf_*", "tt", "st", "w_lnu", "dy", "qcd_*"],
+        "postfit": [*hbbhww_sm, *backgrounds1],
+        "k2v": ["hh_vbf_*", "tt", "st", "w_lnu", "dy", "qcd_*"],
+        "ml": [default_signal_process, "tt", "st", "w_lnu", "dy"],
+        "ml_test": [default_signal_process, "st", "w_lnu"],
+        "mldl": ["hh_ggf_hbb_hvv2l2nu_kl1_kt1", "tt", "st", "dy"],
+        "mlsl": ["hh_ggf_hbb_hvvqqlnu_kl1_kt1", "tt", "st", "w_lnu", "dy"],
+        "test": [default_signal_process, "tt_sl"],
+        "small": [default_signal_process, "tt", "st"],
+        "bkg": ["tt", "st", "w_lnu", "dy"],
+        # signal groups
+        "signal": ["hh_ggf_*", "hh_vbf_*"],
+        "hbv": ["hh_ggf_hbb_hvv_kl1_kt1", "hh_vbf_hbb_hvv_kv1_k2v1_kl1"],
+        "hbw": ["hh_ggf_hbb_hww_kl1_kt1", "hh_vbf_hbb_hww_kv1_k2v1_kl1"],
+        "hbz": ["hh_ggf_hbb_hzz_kl1_kt1", "hh_vbf_hbb_hzz_kv1_k2v1_kl1"],
+        "hbv_ggf": ["hh_ggf_hbb_hvv_kl*_kt1"], "hbv_vbf": ["hh_vbf_hbb_hvv_*"],
+        "hbv_ggf_dl": ["hh_ggf_hbb_hvv2l2nu_kl*_kt1"],
+        "hbv_ggf_sl": ["hh_ggf_hbb_hvvqqlnu_kl*_kt1"],
+        "hbv_vbf_dl": ["hh_vbf_hbb_hvv2l2nu_*"],
+        "hbv_vbf_sl": ["hh_vbf_hbb_hvvqqlnu_*"],
+        "hbw_ggf": ["hh_ggf_hbb_hww_kl*_kt1"], "hbw_vbf": ["hh_vbf_hbb_hww_*"],
+        "hbw_ggf_dl": ["hh_ggf_hbb_hww2l2nu_kl*_kt1"],
+        "hbw_ggf_sl": ["hh_ggf_hbb_hwwqqlnu_kl*_kt1"],
+        "hbw_vbf_dl": ["hh_vbf_hbb_hww2l2nu_*"],
+        "hbw_vbf_sl": ["hh_vbf_hbb_hwwqqlnu_*"],
+        "hbz_ggf": ["hh_ggf_hbb_hzz_kl*_kt1"], "hbz_vbf": ["hh_vbf_hbb_hzz_*"],
+        "hbz_ggf_dl": ["hh_ggf_hbb_hzz2l2nu_kl*_kt1"],
+        "hbz_ggf_sl": ["hh_ggf_hbb_hzzqqlnu_kl*_kt1"],
+        "hbz_vbf_dl": ["hh_vbf_hbb_hzz2l2nu_*"],
+        "hbz_vbf_sl": ["hh_vbf_hbb_hzzqqlnu_*"],
+        # background groups (separated for plotting)
+        "dy_m": ["dy_m4to10", "dy_m10to50", "dy_m50toinf"],
+        # background groups (for yield tables)
+        "table": [*hbbhww_sm, *backgrounds0, "data", "background"],
+        "table0": [*hh_sm, *backgrounds0, "data", "background"],
+        "table1": [*hbbhww_sm, *backgrounds1, "data", "background"],
+        "dy_all": ["dy", "dy_m4to10", "dy_m10to50", "dy_m50toinf", "dy_m50toinf_0j", "dy_m50toinf_1j", "dy_m50toinf_2j"],  # noqa: E501
+        "tt_all": ["tt", "tt_dl", "tt_sl", "tt_fh"],
+        "st_all": ["st", "st_schannel", "st_tchannel", "st_twchannel"],
+        "h_all": ["h", "h_ggf", "h_vbf", "vh", "zh", "zh_gg", "wh", "tth", "ttvh"],
+    }
+    for proc, datasets in config_inst.x.dataset_names.items():
+        remove_generator = lambda x: x.replace("_powheg", "").replace("_madgraph", "").replace("_amcatnlo", "").replace("_pythia8", "").replace("4f_", "")  # noqa: E501
+        config_inst.x.process_groups[f"datasets_{proc}"] = [remove_generator(dataset) for dataset in datasets]
+
+    for group in ("dl3", "dl2", "dl1", "dl", "2much", "2ech", "emuch"):
+        # thanks to double counting removal, we can (and should) now use all datasets in each channel
+        config_inst.x.process_groups[f"d{group}"] = ["data"] + config_inst.x.process_groups[group]
+
+    # dataset groups for conveniently looping over certain datasets
+    # (used in wrapper_factory and during plotting)
+    config_inst.x.dataset_groups = {
+        "all": ["*"],
+        "test": [default_signal_dataset, "tt_sl_powheg"],
+        "small": [default_signal_dataset, "tt_*", "st_*"],
+        "bkg": ["tt_*", "st_*", "w_lnu_*", "dy_*"],
+        "tt": ["tt_*"], "st": ["st_*"], "w": ["w_lnu_*"], "dy": ["dy_*"],
+        "qcd": ["qcd_*"], "qcd_mu": ["qcd_mu*"], "qcd_ele": ["qcd_em*", "qcd_bctoe*"],
+        "signal": ["hh_ggf_*", "hh_vbf_*"], "hh_ggf": ["hh_ggf_*"], "hh_vbf": ["hh_vbf_*"],
+        "ml": ["hh_ggf*kl1_kt1", "tt_*", "st_*", "dy_*", "w_lnu_*"],
+        "dilep": ["tt_*", "st_*", "dy_*", "w_lnu_*", "hh_ggf_*"],
+        "h": ["h_ggf_*", "h_vbf_*", "zh_*", "wph_*", "wmh_*", "tth_*", "ttzh_*", "ttwh_*"],
+    }
+    if config_inst.name == "l22post":
+        config_inst.x.dataset_groups["test123"] = ["tt_dl_powheg", "tt_sl_powheg"]
+    elif config_inst.name == "l22pre":
+        config_inst.x.dataset_groups["test123"] = ["tt_dl_powheg"]
+
+    # category groups for conveniently looping over certain categories
+    # (used during plotting and for rebinning)
+    config_inst.x.category_groups = {
+        "sl": ["sr__1e", "sr__1mu"],
+        "sl_resolved": ["sr__1e__resolved", "sr__1mu__resolved"],
+        "sl_much": ["sr__1mu", "sr__1mu__1b", "sr__1mu__2b"],
+        "sl_ech": ["sr__1e", "sr__1e__1b", "sr__1e__2b"],
+        "sl_much_resolved": ["sr__1mu__resolved", "sr__1mu__resolved__1b", "sr__1mu__resolved__2b"],
+        "sl_ech_resolved": ["sr__1e__resolved", "sr__1e__resolved__1b", "sr__1e__resolved__2b"],
+        "sl_much_boosted": ["sr__1mu__boosted"],
+        "sl_ech_boosted": ["sr__1e__boosted"],
+        "default": ["incl", "sr__1e", "sr__1mu"],
+        "test": ["incl", "sr__1e"],
+        # Single lepton
+        "SR_sl": (
+            "sr__1e__1b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1", "sr__1mu__1b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+            "sr__1e__2b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1", "sr__1mu__2b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+        ),
+        "vbfSR_sl": (
+            "sr__1e__1b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1", "sr__1mu__1b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+            "sr__1e__2b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1", "sr__1mu__2b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+        ),
+        "SR_sl_resolved": (
+            "sr__1e__resolved__1b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+            "sr__1mu__resolved__1b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+            "sr__1e__resolved__2b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+            "sr__1mu__resolved__2b__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+        ),
+        "vbfSR_sl_resolved": (
+            "sr__1e__resolved__1b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+            "sr__1mu__resolved__1b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+            "sr__1e__resolved__2b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+            "sr__1mu__resolved__2b__ml_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+        ),
+        "SR_sl_boosted": (
+            "sr__1e__boosted__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1", "sr__1mu__boosted__ml_hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+        ),
+        "vbfSR_sl_boosted": (
+            "sr__1e__ml_boosted_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+            "sr__1mu__ml_boosted_hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+        ),
+        "BR_sl": (
+            "sr__1e__ml_tt", "sr__1e__ml_st", "sr__1e__ml_v_lep",
+            "sr__1mu__ml_tt", "sr__1mu__ml_st", "sr__1mu__ml_v_lep",
+        ),
+        "BR_dl": bracket_expansion(["sr__{1b,2b}__ml_{tt,st,dy,h}"]),
+        "SR_sig_sl": bracket_expansion(["sr__{1e,1mu}__{1b,2b}__ml_{sig_ggf,sig_vbf}"]),
+        "SR_bkg_sl": bracket_expansion(["sr__{1e,1mu}__{1b,2b}__ml_{tt,st,w_lnu}"]),
+    }
+
+    # variable groups for conveniently looping over certain variables
+    # (used during plotting)
+    config_inst.x.variable_groups = {
+        "gen_vbf": ["vbfpair.deta", "vbfpair.mass", "gen_sec1_eta", "gen_sec2_eta", "gen_sec1_pt", "gen_sec2_pt"],
+        "mli": ["mli_*"],
+        "iso": bracket_expansion(["lepton{0,1}_{pfreliso,minipfreliso,mvatth}"]),
+        "sl": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
+        "sl_resolved": ["n_*", "electron_*", "muon_*", "met_*", "jet*", "bjet*", "ht"],
+        "sl_boosted": ["n_*", "electron_*", "muon_*", "met_*", "fatjet_*"],
+    }
+
+    # shift groups for conveniently looping over certain shifts
+    # (used during plotting)
+    config_inst.x.shift_groups = {
+        "jer": ["nominal", "jer_up", "jer_down"],
+    }
+
+    # selector step groups for conveniently looping over certain steps
+    # (used in cutflow tasks)
+    # NOTE: this could be added as part of the selector init itself
+    config_inst.x.selector_step_groups = {
+        "resolved": ["Trigger", "Lepton", "VetoLepton", "Jet", "Bjet", "VetoTau"],
+        "boosted": ["Trigger", "Lepton", "VetoLepton", "FatJet", "Boosted"],
+        "default": ["Lepton", "VetoLepton", "Jet", "Bjet", "Trigger"],
+        "thesis": ["Lepton", "Muon", "Jet", "Trigger", "Bjet"],  # reproduce master thesis cuts for checks
+        "test": ["Lepton", "Jet", "Bjet"],
+        "dilep": ["Jet", "Bjet", "Lepton", "Trigger"],
+    }
+
+    # plotting settings groups
+    # (used in plotting)
+    config_inst.x.general_settings_groups = {
+        "test1": {"p1": True, "p2": 5, "p3": "text", "skip_legend": True},
+        "default_norm": {"shape_norm": True, "yscale": "log"},
+        "postfit": {
+            "whitespace_fraction": 0.4,
+            "cms_label": "simpw",
+            "yscale": "log",
+            "hide_signal_errors": True,
+        },
+        "data_mc_plots": {
+            # "custom_style_config": "default",  # NOTE: does not work in combination with group
+            "whitespace_fraction": 0.4,
+            "cms_label": "pw",
+            "yscale": "log",
+        },
+    }
+    config_inst.x.process_settings_groups = {
+        "default": {default_signal_process: {"scale": 2000, "unstack": True}},
+        "unstack_all": {proc.name: {"unstack": True} for proc, _, _ in config_inst.walk_processes()},
+        "unstack_signal": {proc.name: {"unstack": True} for proc in config_inst.processes if "HH" in proc.name},
+        "scale_signal": {
+            proc.name: {"unstack": True, "scale": 10000}
+            for proc, _, _ in config_inst.walk_processes() if proc.has_tag("is_signal")
+        },
+        "scale_signal1": {
+            proc.name: {"unstack": True, "scale": "stack"}
+            for proc, _, _ in config_inst.walk_processes() if proc.has_tag("is_signal")
+        },
+        "dilep": {
+            "hh_vbf_hbb_hww2l2nu": {"scale": 90000, "unstack": True},
+            "hh_ggf_hbb_hww2l2nu": {"scale": 10000, "unstack": True},
+        },
+        "dileptest": {
+            "hh_ggf_hbb_hvv2l2nu_kl1_kt1": {"scale": 10000, "unstack": True},
+        },
+        "control": {
+            "hh_ggf_hbb_hvvqqlnu_kl0_kt1": {"scale": 90000, "unstack": True},
+            "hh_ggf_hbb_hvvqqlnu_kl1_kt1": {"scale": 90000, "unstack": True},
+            "hh_ggf_hbb_hvvqqlnu_kl2p45_kt1": {"scale": 90000, "unstack": True},
+            "hh_ggf_hbb_hvvqqlnu_kl5_kt1": {"scale": 90000, "unstack": True},
+        },
+    }
+
+    config_inst.x.variable_settings_groups = {
+        "test": {
+            "mli_mbb": {"rebin": 2, "label": "test"},
+            "mli_mjj": {"rebin": 2},
+        },
+    }
+
+    # groups for custom plot styling
+    config_inst.x.custom_style_config_groups = {
+        "default": {
+            "legend_cfg": {
+                "ncols": 2,
+                "fontsize": 16,
+                "bbox_to_anchor": (0., 0., 1., 1.),
+            },
+            "annotate_cfg": {
+                "xy": (0.05, 0.95),
+                "xycoords": "axes fraction",
+                "fontsize": 16,
+            },
+        },
+        "legend_single_col": {
+            "legend_cfg": {"ncols": 1, "fontsize": 20},
+        },
+        "small_legend": {
+            "legend_cfg": {"ncols": 2, "fontsize": 16},
+        },
+        "no_cat_label": {
+            "legend_cfg": {"ncols": 2, "fontsize": 20},
+            "annotate_cfg": {"text": ""},
+        },
+        "example": {
+            "legend_cfg": {"title": "my custom legend title", "ncols": 2},
+            "ax_cfg": {"ylabel": "my ylabel", "xlim": (0, 100)},
+            "rax_cfg": {"ylabel": "some other ylabel"},
+            "annotate_cfg": {"text": "category label usually here"},
+        },
+    }
+
+    # CSP (calibrator, selector, producer) groups
+    config_inst.x.producer_groups = {
+        "mli": ["ml_inputs", "event_weights"],
+        "mlo": ["ml_dense_default", "event_weights"],
+        "cols": ["mli", "features"],
+    }
+
+    # groups are defined via config.x.category_groups
+    config_inst.x.default_bins_per_category = {
+        # Single lepton
+        "SR_sl": 10,
+        "vbfSR_sl": 5,
+        "BR_sl": 3,
+        "SR_sl_resolved": 10,
+        "SR_sl_boosted": 5,
+        "vbfSR_sl_resolved": 5,
+        "vbfSR_sl_boosted": 3,
+        "SR_sig_sl": 10,
+        "SR_bkg_sl": 3,
+    }
+
+    is_signal_sm = lambda proc_name: "kl1_kt1" in proc_name or "kv1_k2v1_kl1" in proc_name
+    is_signal_sm_ggf = lambda proc_name: "kl1_kt1" in proc_name
+    is_signal_sm_vbf = lambda proc_name: "kv1_k2v1_kl1" in proc_name
+    # is_gghh_sm = lambda proc_name: "kl1_kt1" in proc_name
+    # is_qqhh_sm = lambda proc_name: "kv1_k2v1_kl1" in proc_name
+    # is_signal_ggf_kl1 = lambda proc_name: "kl1_kt1" in proc_name and "hh_ggf" in proc_name
+    # is_signal_vbf_kl1 = lambda proc_name: "kv1_k2v1_kl1" in proc_name and "hh_vbf" in proc_name
+    is_background = lambda proc_name: (
+        "hbb_hvv" not in proc_name and "hbb_hww" not in proc_name and "hbb_hzz" not in proc_name
+    )
+
+    config_inst.x.inference_category_rebin_processes = {
+        # Single lepton
+        "SR_sl": is_signal_sm_ggf,
+        "vbfSR_sl": is_signal_sm_vbf,
+        "SR_sl_resolved": is_signal_sm,
+        "SR_sl_boosted": is_signal_sm,
+        "vbfSR_sl_resolved": is_signal_sm,
+        "vbfSR_sl_boosted": is_signal_sm,
+        "BR_sl": is_background,
+        "SR_sig_sl": is_signal_sm,
+        "SR_bkg_sl": is_background,
+    }

--- a/hbw/config/trigger.py
+++ b/hbw/config/trigger.py
@@ -278,6 +278,7 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["mu", "mm", "emu", "mue", "mixed"],
             "data_stream": "data_mu",
+            "L1_seeds": ["SingleMu22"],
         },
         tags={"single_trigger", "single_mu"},
     )
@@ -303,6 +304,7 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["mm"],
             "data_stream": "data_mu",
+            "L1_seeds": ["DoubleMu_15_7"],
         },
         tags={"di_trigger", "di_mu"},
     )
@@ -321,6 +323,18 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["e", "ee", "emu", "mue", "mixed"],
             "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+            "L1_seeds": [
+                "SingleEG38er2p5",
+                "SingleEG40er2p5",
+                "SingleEG42er2p5",
+                "SingleEG45er2p5",
+                "SingleEG36er2p5",
+                "SingleIsoEG30er2p1",
+                "SingleIsoEG32er2p1",
+                "SingleIsoEG30er2p5",
+                "SingleIsoEG32er2p5",
+                "SingleIsoEG34er2p5",
+            ],
         },
         tags={"single_trigger", "single_e"},
     )
@@ -347,6 +361,21 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["ee"],
             "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+            "L1_seeds": [
+                "SingleEG38er2p5",
+                "SingleEG40er2p5",
+                "SingleEG42er2p5",
+                "SingleEG45er2p5",
+                "SingleEG36er2p5",
+                "SingleIsoEG30er2p1",
+                "SingleIsoEG32er2p1",
+                "SingleIsoEG30er2p5",
+                "SingleIsoEG32er2p5",
+                "SingleIsoEG34er2p5",
+                "DoubleEG_25_12_er2p5",
+                "DoubleEG_25_14_er2p5",
+                "DoubleEG_LooseIso22_12_er2p5",
+            ],
         },
         tags={"di_trigger", "di_e"},
     )
@@ -364,6 +393,11 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["e", "ee", "emu", "mue", "mixed"],
             "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+            "L1_seeds": [
+                "SingleEG40er2p5",
+                "SingleEG42er2p5",
+                "SingleEG45er2p5",
+            ],
         },
     )
     di_e33_noniso = Trigger(
@@ -386,6 +420,19 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["ee"],
             "data_stream": "data_egamma" if config.x.run == 3 else "data_e",
+            "L1_seeds": [
+                "SingleEG36er2p5",
+                "SingleEG38er2p5",
+                "SingleEG40er2p5",
+                "SingleEG42er2p5",
+                "SingleEG45er2p5",
+                "DoubleEG_25_12_er2p5",
+                "DoubleEG_25_14_er2p5",
+                "SingleJet180",
+                "SingleJet200",
+                "SingleTau120er2p1",
+                "SingleTau130er2p1",
+            ],
         },
     )
     mixed_mue = Trigger(
@@ -410,6 +457,10 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["mue", "mixed"],
             "data_stream": "data_muoneg",
+            "L1_seeds": [
+                "Mu20_EG10er2p5",
+                "SingleMu22",
+            ],
         },
         tags={"mixed_trigger", "mixed_mue"},
     )
@@ -435,6 +486,12 @@ def add_triggers(config: od.Config) -> od.UniqueObjectIndex[Trigger]:
         aux={
             "channels": ["emu", "mixed"],
             "data_stream": "data_muoneg",
+            "L1_seeds": [
+                "Mu7_EG20er2p5",
+                "Mu7_EG23er2p5",
+                "Mu7_LooseIsoEG20er2p5",
+                "Mu7_LooseIsoEG23er2p5",
+            ],
         },
         tags={"mixed_trigger", "mixed_emu"},
     )

--- a/hbw/inference/sl.py
+++ b/hbw/inference/sl.py
@@ -1,0 +1,278 @@
+# coding: utf-8
+
+"""
+hbw(sl) inference model.
+"""
+
+import hbw.inference.constants as const  # noqa
+from hbw.inference.base import HBWInferenceModelBase
+
+
+#
+# Defaults for all the Inference Model parameters
+#
+
+# used to set default requirements for cf.CreateDatacards based on the config
+ml_model_name = "sl_22post"
+
+# All processes to be included in the final datacard
+processes = [
+    "hh_ggf_hbb_hwwqqlnu_kl0_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl1_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl2p45_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl5_kt1",
+    "hh_vbf_hbb_hwwqqlnu_kv1_k2v1_kl1",
+    "hh_vbf_hbb_hwwqqlnu_kv1_k2v0_kl1",
+    "hh_vbf_hbb_hwwqqlnu_kvm0p962_k2v0p959_klm1p43",
+    "hh_vbf_hbb_hwwqqlnu_kvm1p21_k2v1p94_klm0p94",
+    "hh_vbf_hbb_hwwqqlnu_kvm1p6_k2v2p72_klm1p36",
+    "hh_vbf_hbb_hwwqqlnu_kvm1p83_k2v3p57_klm3p39",
+    "tt",
+    "st_tchannel", "st_twchannel",
+    "dy",
+    "w_lnu",
+    "qcd",
+    "vv",
+]
+
+# All categories to be included in the final datacard
+config_categories = [
+    # Signal regions
+    "sr__1e__1b__ml_sig_ggf",
+    "sr__1e__2b__ml_sig_ggf",
+    "sr__1e__1b__ml_sig_vbf",
+    "sr__1e__2b__ml_sig_vbf",
+    "sr__1mu__1b__ml_sig_ggf",
+    "sr__1mu__2b__ml_sig_ggf",
+    "sr__1mu__1b__ml_sig_vbf",
+    "sr__1mu__2b__ml_sig_vbf",
+    # Background regions
+    "sr__1e__1b__ml_tt",
+    "sr__1e__2b__ml_tt",
+    "sr__1e__1b__ml_st",
+    "sr__1e__2b__ml_st",
+    "sr__1e__1b__ml_w_lnu",
+    "sr__1e__2b__ml_w_lnu",
+    "sr__1mu__1b__ml_tt",
+    "sr__1mu__2b__ml_tt",
+    "sr__1mu__1b__ml_st",
+    "sr__1mu__2b__ml_st",
+    "sr__1mu__1b__ml_w_lnu",
+    "sr__1mu__2b__ml_w_lnu",
+]
+
+rate_systematics = [
+    # Lumi: should automatically choose viable uncertainties based on campaign
+    "lumi_13TeV_2016",
+    "lumi_13TeV_2017",
+    "lumi_13TeV_1718",
+    "lumi_13TeV_2022",
+    "lumi_13TeV_2023",
+    "lumi_13TeV_correlated",
+    # Rate QCDScale uncertainties
+    "QCDScale_ttbar",
+    "QCDScale_V",
+    "QCDScale_VV",
+    "QCDScale_VVV",
+    "QCDScale_ggH",
+    "QCDScale_qqH",
+    "QCDScale_VH",
+    "QCDScale_ttH",
+    "QCDScale_bbH",
+    "QCDScale_hh_ggf",  # should be included in inference model (THU_HH)
+    "QCDScale_hh_vbf",
+    "QCDScale_VHH",
+    "QCDScale_ttHH",
+    # Rate PDF uncertainties
+    "pdf_gg",
+    "pdf_qqbar",
+    "pdf_qg",
+    "pdf_Higgs_gg",
+    "pdf_Higgs_qqbar",
+    "pdf_Higgs_qg",  # none so far
+    "pdf_Higgs_ttH",
+    "pdf_Higgs_bbH",  # removed
+    "pdf_Higgs_hh_ggf",
+    "pdf_Higgs_hh_vbf",
+    "pdf_VHH",
+    "pdf_ttHH",
+]
+
+shape_systematics = [
+    # Shape Scale uncertainties
+    # "murf_envelope_hh_ggf_hbb_hvv2l2nu_kl1_kt1",
+    "murf_envelope_tt",
+    "murf_envelope_st",
+    "murf_envelope_dy",
+    "murf_envelope_w_lnu",
+    # "murf_envelope_ttv",
+    # "murf_envelope_vv",
+    # "murf_envelope_h",
+    # Shape PDF Uncertainties
+    "pdf_shape_tt",
+    "pdf_shape_st",
+    "pdf_shape_dy",
+    "pdf_shape_w_lnu",
+    # "pdf_shape_ttv",
+    # "pdf_shape_vv",
+    # "pdf_shape_h",
+    # Scale Factors
+    "btag_hf",
+    "btag_lf",
+    "btag_hfstats1_{year}",
+    "btag_hfstats2_{year}",
+    "btag_lfstats1_{year}",
+    "btag_lfstats2_{year}",
+    "btag_cferr1",
+    "btag_cferr2",
+    "mu_id_sf",
+    "mu_iso_sf",
+    "e_sf",
+    # "trigger_sf",
+    "minbias_xs",
+    "top_pt",
+]
+
+# All systematics to be included in the final datacard
+systematics = rate_systematics + shape_systematics
+
+default_cls_dict = {
+    "ml_model_name": ml_model_name,
+    "processes": processes,
+    "config_categories": config_categories,
+    "systematics": rate_systematics,
+    "mc_stats": True,
+    "skip_data": True,
+}
+
+hhprocs = lambda hhdecay: [
+    f"hh_vbf_{hhdecay}_kv1p74_k2v1p37_kl14p4",
+    f"hh_vbf_{hhdecay}_kvm0p758_k2v1p44_klm19p3",
+    f"hh_vbf_{hhdecay}_kvm0p012_k2v0p03_kl10p2",
+    f"hh_vbf_{hhdecay}_kvm2p12_k2v3p87_klm5p96",
+    f"hh_vbf_{hhdecay}_kv1_k2v1_kl1",
+    f"hh_vbf_{hhdecay}_kv1_k2v0_kl1",
+    f"hh_vbf_{hhdecay}_kvm0p962_k2v0p959_klm1p43",
+    f"hh_vbf_{hhdecay}_kvm1p21_k2v1p94_klm0p94",
+    f"hh_vbf_{hhdecay}_kvm1p6_k2v2p72_klm1p36",
+    f"hh_vbf_{hhdecay}_kvm1p83_k2v3p57_klm3p39",
+    f"hh_ggf_{hhdecay}_kl0_kt1",
+    f"hh_ggf_{hhdecay}_kl1_kt1",
+    f"hh_ggf_{hhdecay}_kl2p45_kt1",
+    f"hh_ggf_{hhdecay}_kl5_kt1",
+]
+backgrounds = [
+    # TODO: merge st_schannel, st_tchannel
+    "st_tchannel",
+    "st_twchannel",
+    # "st_schannel",  # Not datasets anyways
+    "tt",
+    # "st",
+    # "ttw",  # TODO: dataset not working?
+    # "ttz",
+    "dy",
+    "w_lnu",
+    # "vv",
+    # "h_ggf", "h_vbf", "zh", "wh", "zh_gg", "tth",
+    # "ttv",  # TODO
+    # "ttvv",  # TODO
+    # "vvv",  # TODO
+    # TODO: add thq, thw, bbh
+    "qcd",  # probably not needed
+]
+
+processes_dict = {
+    "default": [*backgrounds, *hhprocs("hbb_hww2l2nu")],
+    "hww": [*backgrounds, *hhprocs("hbb_hww")],
+    "hwwzztt": [*backgrounds, *hhprocs("hbb_hww"), *hhprocs("hbb_hzz"), *hhprocs("hbb_htt")],
+}
+
+
+def config_variable_binary_ggf_and_vbf(self, config_cat_inst):
+    """
+    Function to set the config variable for the binary model.
+    """
+    if "sig_ggf" in config_cat_inst.name:
+        return "logit_mlscore.sig_ggf_binary"
+    elif "sig_vbf" in config_cat_inst.name:
+        return "logit_mlscore.sig_vbf_binary"
+    elif config_cat_inst.x.root_cats.get("dnn"):
+        return "mlscore.max_score"
+    else:
+        raise ValueError(f"Category {config_cat_inst.name} is not a DNN category.")
+
+
+sl = HBWInferenceModelBase.derive("sl", cls_dict=default_cls_dict)
+
+sl_syst = sl.derive("sl_syst", cls_dict={"systematics": systematics})
+
+cls_dict_test = {
+    "ml_model_name": "sl_22post",
+    "processes": [
+        "hh_ggf_hbb_hwwqqlnu_kl0_kt1",
+        "hh_ggf_hbb_hwwqqlnu_kl1_kt1",
+        "hh_ggf_hbb_hwwqqlnu_kl2p45_kt1",
+        "hh_ggf_hbb_hwwqqlnu_kl5_kt1",
+        "tt",
+    ],
+    "config_categories": [
+        "sr__1e__ml_sig_ggf",
+        "sr__1e__ml_tt",
+    ],
+    "systematics": [
+        "lumi_13TeV_2016",
+        "lumi_13TeV_2017",
+        "lumi_13TeV_1718",
+        "lumi_13TeV_2022",
+        "lumi_13TeV_2023",
+        "lumi_13TeV_correlated",
+    ],
+}
+
+sl_test = sl.derive("sl_test", cls_dict=cls_dict_test)
+
+processes_ggf = [
+    "hh_ggf_hbb_hwwqqlnu_kl0_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl1_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl2p45_kt1",
+    "hh_ggf_hbb_hwwqqlnu_kl5_kt1",
+    # "hh_vbf_hbb_hwwqqlnu_kv1_k2v1_kl1",
+    # "hh_vbf_hbb_hwwqqlnu_kv1_k2v0_kl1",
+    # "hh_vbf_hbb_hwwqqlnu_kvm0p962_k2v0p959_klm1p43",
+    # "hh_vbf_hbb_hwwqqlnu_kvm1p21_k2v1p94_klm0p94",
+    # "hh_vbf_hbb_hwwqqlnu_kvm1p6_k2v2p72_klm1p36",
+    # "hh_vbf_hbb_hwwqqlnu_kvm1p83_k2v3p57_klm3p39",
+    "tt",
+    "st_tchannel", "st_twchannel",
+    "dy",
+    "w_lnu",
+    "qcd",
+    "vv",
+]
+
+config_categories_ggf = [
+    # Signal regions
+    "sr__1e__1b__ml_sig_ggf",
+    "sr__1e__2b__ml_sig_ggf",
+    "sr__1mu__1b__ml_sig_ggf",
+    "sr__1mu__2b__ml_sig_ggf",
+    # Background regions
+    "sr__1e__1b__ml_tt",
+    "sr__1e__2b__ml_tt",
+    "sr__1e__1b__ml_st",
+    "sr__1e__2b__ml_st",
+    "sr__1e__1b__ml_w_lnu",
+    "sr__1e__2b__ml_w_lnu",
+    "sr__1mu__1b__ml_tt",
+    "sr__1mu__2b__ml_tt",
+    "sr__1mu__1b__ml_st",
+    "sr__1mu__2b__ml_st",
+    "sr__1mu__1b__ml_w_lnu",
+    "sr__1mu__2b__ml_w_lnu",
+]
+
+sl_syst_ggf = sl.derive("sl_syst_ggf", cls_dict={
+    "systematics": systematics,
+    "processes": processes_ggf,
+    "config_categories": config_categories_ggf,
+})

--- a/hbw/ml/derived/sl.py
+++ b/hbw/ml/derived/sl.py
@@ -1,0 +1,252 @@
+# coding: utf-8
+
+"""
+ML models using the MLClassifierBase and Mixins
+"""
+
+from __future__ import annotations
+
+from columnflow.types import Union
+
+import law
+
+from columnflow.util import maybe_import
+
+from hbw.ml.base import MLClassifierBase
+from hbw.ml.mixins import DenseModelMixin, ModelFitMixin
+
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+logger = law.logger.get_logger(__name__)
+
+
+class DenseClassifierSL(DenseModelMixin, ModelFitMixin, MLClassifierBase):
+
+    combine_processes = ()
+
+    _default__processes: tuple = (
+        "hh_ggf_hbb_hvvqqlnu_kl0_kt1",
+        "hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+        "hh_ggf_hbb_hvvqqlnu_kl2p45_kt1",
+        "hh_ggf_hbb_hvvqqlnu_kl5_kt1",
+        "hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+        "hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1",
+        "hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43",
+        "hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94",
+        "hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36",
+        "hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39",
+        "tt",
+        "st",
+        # "v_lep",
+        "w_lnu",
+        # "dy",
+        # "h",
+    )
+    train_nodes: dict = {
+        "sig_ggf": {
+            "ml_id": 0,
+            "label": r"HH_{GGF}",
+            "color": "#000000",  # black
+            "class_factor_mode": "equal",
+            "sub_processes": (
+                "hh_ggf_hbb_hvvqqlnu_kl0_kt1",
+                "hh_ggf_hbb_hvvqqlnu_kl1_kt1",
+                "hh_ggf_hbb_hvvqqlnu_kl2p45_kt1",
+                "hh_ggf_hbb_hvvqqlnu_kl5_kt1",
+            ),
+        },
+        "sig_vbf": {
+            "ml_id": 1,
+            "label": r"HH_{VBF}",
+            "color": "#999999",  # grey
+            "class_factor_mode": "equal",
+            "sub_processes": (
+                "hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1",
+                "hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1",
+                "hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43",
+                "hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94",
+                "hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36",
+                "hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39",
+            ),
+        },
+        "tt": {"ml_id": 2},
+        "st": {"ml_id": 3},
+        "w_lnu": {"ml_id": 4},
+        # "dy": {"ml_id": 4},
+        # "h": {"ml_id": 5},
+    }
+    _default__class_factors: dict = {
+        "sig_ggf": 1,
+        "sig_vbf": 1,
+        "tt": 1,
+        "st": 1,
+        "w_lnu": 1,
+        # "dy": 1,
+        # "h": 1,
+    }
+
+    _default__sub_process_class_factors = {
+        "hh_ggf_hbb_hvvqqlnu_kl0_kt1": 1,
+        "hh_ggf_hbb_hvvqqlnu_kl1_kt1": 1,
+        "hh_ggf_hbb_hvvqqlnu_kl2p45_kt1": 1,
+        "hh_ggf_hbb_hvvqqlnu_kl5_kt1": 1,
+    }
+
+    input_features = [
+        # event features
+        "mli_ht", "mli_lt", "mli_n_jet", "mli_n_btag",
+        "mli_b_score_sum",
+        # bb system
+        "mli_dr_bb", "mli_dphi_bb", "mli_mbb",
+        # jj system
+        "mli_dr_jj", "mli_dphi_jj", "mli_mjj",
+        # lnu system
+        "mli_dphi_lnu", "mli_mlnu",
+        # angles to lepton
+        "mli_mindr_lb", "mli_mindr_lj",
+        "mli_dphi_wl",
+        # ww system
+        "mli_mjjlnu", "mli_mjjl",
+        # HH system
+        "mli_dphi_bb_jjlnu", "mli_dr_bb_jjlnu",
+        "mli_dphi_bb_jjl", "mli_dr_bb_jjl", "mli_dphi_bb_nu", "mli_dphi_jj_nu", "mli_dr_bb_l", "mli_dr_jj_l",
+        "mli_mbbjjlnu", "mli_mbbjjl", "mli_mindr_jj",
+        "mli_s_min",
+        # VBF features
+        "mli_vbf_deta", "mli_vbf_mass", "mli_vbf_tag", "mli_met_pt",
+    ] + [
+        f"mli_{obj}_{var}"
+        for obj in ["b1", "b2", "j1", "j2"]
+        for var in ["pt", "eta", "b_score"]
+    ] + [
+        f"mli_{obj}_{var}"
+        for obj in ["lep"]
+        for var in ["pt", "eta"]
+    ]
+
+    store_name: str = "inputs_inclusive"
+
+    folds: int = 5
+    negative_weights: str = "ignore"
+
+    # overwriting DenseModelMixin parameters
+    _default__activation: str = "relu"
+    _default__layers: tuple = (512, 512, 512)
+    _default__dropout: float = 0.20
+    _default__learningrate: float = 0.00050
+
+    # overwriting ModelFitMixin parameters
+    _default__callbacks: set = {
+        "backup", "checkpoint", "reduce_lr",
+        # "early_stopping",
+    }
+    remove_backup: bool = True
+    _default__reduce_lr_factor: float = 0.8
+    _default__reduce_lr_patience: int = 3
+    _default__epochs: int = 100
+    _default__batchsize: int = 2 ** 12
+    steps_per_epoch: Union[int, str] = "iter_smallest_process"
+
+    # parameters to add into the `parameters` attribute to determine the 'parameters_repr' and to store in a yaml file
+    bookkeep_params: set[str] = {
+        # base params
+        "data_loader", "input_features", "train_val_test_split",
+        "processes", "sub_process_class_factors", "class_factors", "train_nodes",
+        "negative_weights", "folds",
+        # DenseModelMixin
+        "activation", "layers", "dropout", "learningrate",
+        # ModelFitMixin
+        "callbacks", "reduce_lr_factor", "reduce_lr_patience",
+        "epochs", "batchsize",
+    }
+
+    # parameters that can be overwritten via command line
+    settings_parameters: set[str] = {
+        # base params
+        "processes", "class_factors", "sub_process_class_factors",
+        # DenseModelMixin
+        "activation", "layers", "dropout", "learningrate",
+        # ModelFitMixin
+        "callbacks", "reduce_lr_factor", "reduce_lr_patience",
+        "epochs", "batchsize",
+    }
+
+    def __init__(
+            self,
+            *args,
+            **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+    def cast_ml_param_values(self):
+        super().cast_ml_param_values()
+
+    def setup(self) -> None:
+        super().setup()
+
+
+#
+# configs
+#
+
+processes = {
+    "default": DenseClassifierSL._default__processes,
+    "merge_hh": ["sig_ggf", "sig_vbf", "tt", "st", "dy", "h"],
+}
+input_features = {
+    "default": DenseClassifierSL.input_features,
+    "previous": [
+        # event features
+        "mli_ht", "mli_n_jet", "mli_n_btag",
+        "mli_b_score_sum",
+        # bb system
+        "mli_dr_bb", "mli_dphi_bb", "mli_mbb", "mli_bb_pt",
+        "mli_mindr_lb",
+        # ll system
+        "mli_mll", "mli_dr_ll", "mli_dphi_ll", "mli_ll_pt",
+        "mli_min_dr_llbb",
+        "mli_dphi_bb_nu", "mli_dphi_bb_llMET", "mli_mllMET",
+        "mli_mbbllMET", "mli_dr_bb_llMET",
+        # VBF features
+        "mli_vbf_deta", "mli_vbf_mass", "mli_vbf_tag",
+        # low-level features
+        "mli_met_pt",
+    ] + [
+        f"mli_{obj}_{var}"
+        for obj in ["b1", "b2", "j1"]
+        for var in ["pt", "eta", "b_score"]
+    ] + [
+        f"mli_{obj}_{var}"
+        for obj in ["lep", "lep2"]
+        for var in ["pt", "eta"]
+    ],
+}
+class_factors = {
+    "default": DenseClassifierSL._default__class_factors,
+    "ones": {},  # defaults to 1 (NOTE: do not try to use defaultdict! does not work with hash generation)
+    "benchmark": {
+        "sig_ggf": 1,
+        "sig_vbf": 1,
+        "tt": 8,
+        "st": 2,
+        "dy": 2,
+        "h": 1,
+    },
+}
+#
+# derived MLModels
+#
+
+sl_22post_test = DenseClassifierSL.derive("sl_22post_test", cls_dict={
+    "training_configs": lambda self, requested_configs: ["l22post"],
+    "processes": ["hh_ggf_hbb_hvvqqlnu_kl1_kt1", "tt"],
+    "train_nodes": {"hh_ggf_hbb_hvvqqlnu_kl1_kt1": {"ml_id": 0}, "tt": {"ml_id": 1}},
+    "epochs": 10,
+},
+)
+sl_22post = DenseClassifierSL.derive("sl_22post", cls_dict={
+    "training_configs": lambda self, requested_configs: ["c22post"],
+},
+)

--- a/hbw/production/ml_inputs.py
+++ b/hbw/production/ml_inputs.py
@@ -243,12 +243,12 @@ def sl_ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column_f32(events, "mli_dr_jj", events.Lightjet[:, 0].delta_r(events.Lightjet[:, 1]))
     events = set_ak_column_f32(events, "mli_dphi_jj", abs(events.Lightjet[:, 0].delta_phi(events.Lightjet[:, 1])))
 
-    wjj = events.Lightjet[:, 0] + events.Lightjet[:, 1] * 1
+    wjj = (events.Lightjet[:, 0] + events.Lightjet[:, 1]) * 1
     events = set_ak_column_f32(events, "mli_mjj", wjj.mass)
 
     # wlnu features
     # NOTE: we might want to consider neutrino reconstruction or transverse masses instead when including MET
-    wlnu = events[met_name] + events.Lepton[:, 0] * 1
+    wlnu = (events[met_name] + events.Lepton[:, 0]) * 1
     events = set_ak_column_f32(events, "mli_mlnu", wlnu.mass)
     events = set_ak_column_f32(events, "mli_dphi_lnu", abs(events.Lepton[:, 0].delta_phi(events[met_name])))
     events = set_ak_column_f32(events, "mli_dphi_wl", abs(wlnu.delta_phi(events.Lepton[:, 0])))
@@ -261,7 +261,7 @@ def sl_ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column_f32(events, "mli_mjjl", hww_vis.mass)
 
     # hh system angles
-    hbb = events.Bjet[:, 0] + events.Bjet[:, 1] * 1
+    hbb = (events.Bjet[:, 0] + events.Bjet[:, 1]) * 1
 
     events = set_ak_column_f32(events, "mli_dphi_bb_jjlnu", abs(hbb.delta_phi(hww)))
     events = set_ak_column_f32(events, "mli_dr_bb_jjlnu", hbb.delta_r(hww))

--- a/hbw/production/ml_inputs.py
+++ b/hbw/production/ml_inputs.py
@@ -243,12 +243,12 @@ def sl_ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column_f32(events, "mli_dr_jj", events.Lightjet[:, 0].delta_r(events.Lightjet[:, 1]))
     events = set_ak_column_f32(events, "mli_dphi_jj", abs(events.Lightjet[:, 0].delta_phi(events.Lightjet[:, 1])))
 
-    wjj = events.Lightjet[:, 0] + events.Lightjet[:, 1]
+    wjj = events.Lightjet[:, 0] + events.Lightjet[:, 1] * 1
     events = set_ak_column_f32(events, "mli_mjj", wjj.mass)
 
     # wlnu features
     # NOTE: we might want to consider neutrino reconstruction or transverse masses instead when including MET
-    wlnu = events[met_name] + events.Lepton[:, 0]
+    wlnu = events[met_name] + events.Lepton[:, 0] * 1
     events = set_ak_column_f32(events, "mli_mlnu", wlnu.mass)
     events = set_ak_column_f32(events, "mli_dphi_lnu", abs(events.Lepton[:, 0].delta_phi(events[met_name])))
     events = set_ak_column_f32(events, "mli_dphi_wl", abs(wlnu.delta_phi(events.Lepton[:, 0])))
@@ -261,7 +261,7 @@ def sl_ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column_f32(events, "mli_mjjl", hww_vis.mass)
 
     # hh system angles
-    hbb = events.Bjet[:, 0] + events.Bjet[:, 1]
+    hbb = events.Bjet[:, 0] + events.Bjet[:, 1] * 1
 
     events = set_ak_column_f32(events, "mli_dphi_bb_jjlnu", abs(hbb.delta_phi(hww)))
     events = set_ak_column_f32(events, "mli_dr_bb_jjlnu", hbb.delta_r(hww))

--- a/hbw/production/trigger.py
+++ b/hbw/production/trigger.py
@@ -165,7 +165,7 @@ muon_trigger_weights = muon_weights.derive("muon_trigger_weights", cls_dict={
 
 
 @producer(
-    uses={muon_trigger_weights},
+    uses={muon_trigger_weights, "Muon.{pt,eta,phi,mass}", prepare_objects},
 )
 def sl_trigger_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """

--- a/hbw/scripts/test_config.py
+++ b/hbw/scripts/test_config.py
@@ -10,7 +10,7 @@ from columnflow.tasks.framework.base import AnalysisTask
 default_analysis = law.config.get_expanded("analysis", "default_analysis")
 default_config = law.config.get_expanded("analysis", "default_config")
 analysis_inst = ana = AnalysisTask.get_analysis_inst(default_analysis)
-config_inst = cfg = ana.get_config("c22post")
+config_inst = cfg = ana.get_config(default_config)
 
 print(" ================ Processes ======================")
 process_insts = cfg.processes

--- a/hbw/scripts/test_config.py
+++ b/hbw/scripts/test_config.py
@@ -10,7 +10,7 @@ from columnflow.tasks.framework.base import AnalysisTask
 default_analysis = law.config.get_expanded("analysis", "default_analysis")
 default_config = law.config.get_expanded("analysis", "default_config")
 analysis_inst = ana = AnalysisTask.get_analysis_inst(default_analysis)
-config_inst = cfg = ana.get_config(default_config)
+config_inst = cfg = ana.get_config("c22post")
 
 print(" ================ Processes ======================")
 process_insts = cfg.processes

--- a/hbw/selection/dl_remastered.py
+++ b/hbw/selection/dl_remastered.py
@@ -224,7 +224,7 @@ def dl1(
     events, lepton_results = self[dl_lepton_selection](events, stats, **kwargs)
     results += lepton_results
 
-    # # trigger selection
+    # trigger selection
     events, trigger_results = self[hbw_trigger_selection](events, lepton_results, stats, **kwargs)
     results += trigger_results
 
@@ -389,3 +389,14 @@ dl1_mu18 = dl1.derive(
         "ele2_pt": 15.,
     },
 )
+
+# selectors version for scale factor testing and calculation
+dl1_test = dl1.derive("dl1_test", cls_dict={"version": 3})
+dl1_no_trigger = dl1.derive("dl1_no_trigger", cls_dict={"version": 1})
+dl1_low_lep = dl1.derive("dl1_low_lep", cls_dict={
+    "version": 1,
+    "mu_pt": 15.,
+    "ele_pt": 15.,
+    "mu2_pt": 15.,
+    "ele2_pt": 15.,
+})

--- a/hbw/selection/sl_remastered.py
+++ b/hbw/selection/sl_remastered.py
@@ -195,6 +195,13 @@ def sl_lepton_selection_init(self: Selector) -> None:
             "e": ["Ele30_WPTight_Gsf"],
             "mu": ["IsoMu24"],
         })
+    elif year == 2023:
+        self.config_inst.x.mu_pt = self.config_inst.x("mu_pt", 25)
+        self.config_inst.x.ele_pt = self.config_inst.x("ele_pt", 31)
+        self.config_inst.x.trigger = self.config_inst.x("trigger", {
+            "e": ["Ele30_WPTight_Gsf"],
+            "mu": ["IsoMu24"],
+        })
     else:
         raise Exception(f"Single lepton trigger not implemented for year {year}")
 
@@ -333,3 +340,5 @@ sl1_no_trig = sl1.derive("sl1_no_trig", cls_dict={
     "ele_pt": 15.,
     "ele2_pt": 15.,
 })
+
+sl1_test = sl1.derive("sl1_test", cls_dict={"version": 0})

--- a/hbw/selection/trigger.py
+++ b/hbw/selection/trigger.py
@@ -49,7 +49,7 @@ def trigger_selection(
 
     NOTE: to use this selector, the *triggers* auxiliary must be set in the config.
     """
-    trigger_ids = []
+    trigger_ids = ak.Array([[0]] * len(events))
 
     trigger_data = ak.Array({
         "any_fired": ak.zeros_like(events.run, dtype=np.bool_),
@@ -105,6 +105,11 @@ def trigger_selection(
         # final trigger decision
         fired_and_all_legs_match = fired & all_legs_match
 
+        # check if an unprescaled L1 seed has fired as well
+        l1_seeds_fired = ak_any([events.L1[l1_seed] for l1_seed in trigger.x.L1_seeds])
+
+        fired_and_all_legs_match_and_l1_fired = fired_and_all_legs_match & l1_seeds_fired
+
         # store all intermediate results for subsequent selectors
         trigger_data = set_ak_bool(
             trigger_data,
@@ -116,11 +121,16 @@ def trigger_selection(
             f"{trigger.name}.fired_and_all_legs_match",
             fired_and_all_legs_match,
         )
-        ids = ak.where(fired_and_all_legs_match, np.float32(trigger.id), np.float32(np.nan))
-        trigger_ids.append(ak.singletons(ak.nan_to_none(ids)))
+        trigger_data = set_ak_bool(
+            trigger_data,
+            f"{trigger.name}.fired_and_all_legs_match_and_l1_fired",
+            fired_and_all_legs_match_and_l1_fired,
+        )
+        ids = ak.where(fired_and_all_legs_match_and_l1_fired, np.float32(trigger.id), np.float32(np.nan))
+        trigger_ids = ak.concatenate([trigger_ids, ak.singletons(ak.nan_to_none(ids))], axis=1)
 
     # store the fired trigger ids
-    trigger_ids = ak.concatenate(trigger_ids, axis=1)
+    # trigger_ids = ak.concatenate(trigger_ids, axis=1)
     events = set_ak_int32(events, "trigger_ids", trigger_ids)
     events = set_ak_bool(events, "trigger_data", trigger_data)
 
@@ -147,6 +157,12 @@ def trigger_selection_init(self: Selector) -> None:
         for trigger in self.config_inst.x.triggers
         # if trigger.applies_to_dataset(self.dataset_inst)
     }
+    # add L1 seed columns
+    for trigger in self.config_inst.x.triggers:
+        self.uses |= {
+            f"L1.{l1_seed}"
+            for l1_seed in trigger.x.L1_seeds
+        }
 
     # testing: add HLT columns to keep columns
     self.config_inst.x.keep_columns["cf.ReduceEvents"] |= {
@@ -241,6 +257,10 @@ def data_double_counting(
         return events, SelectionResult(steps={"data_double_counting": np.ones(len(events), dtype=np.bool_)})
 
     process_inst = self.dataset_inst.processes.get_first()
+
+    if process_inst.name == "data_jethtmet":
+        # return always true for data_jethtmet
+        return events, SelectionResult(steps={"data_double_counting": np.ones(len(events), dtype=np.bool_)})
 
     data_processes_ordered = [f"data_{stream}" for stream in self.config_inst.x.data_streams]
     if process_inst.name not in data_processes_ordered:

--- a/hbw/selection/trigger.py
+++ b/hbw/selection/trigger.py
@@ -49,7 +49,7 @@ def trigger_selection(
 
     NOTE: to use this selector, the *triggers* auxiliary must be set in the config.
     """
-    trigger_ids = ak.Array([[0]] * len(events))
+    trigger_ids = ak.singletons(ak.zeros_like(events.run, dtype=np.int64))
 
     trigger_data = ak.Array({
         "any_fired": ak.zeros_like(events.run, dtype=np.bool_),

--- a/hbw/weight/default.py
+++ b/hbw/weight/default.py
@@ -288,3 +288,11 @@ from hbw.categorization.categories import mask_fn_highpt, mask_fn_gen_barrel, ma
 no_btag_weight.derive("no_btag_weight_highpt", cls_dict={"categorizer_cls": mask_fn_highpt})
 base.derive("gen_barrel", cls_dict={"categorizer_cls": mask_fn_gen_barrel})
 base.derive("forward_handling", cls_dict={"categorizer_cls": mask_fn_forward_handling})
+
+
+# additional hist producers for scale factors
+from trigger.trigger_cats import mask_fn_dl_orth_with_l1_seeds
+
+dl_orth_with_l1_seeds = default_hist_producer.derive("dl_orth_with_l1_seeds", cls_dict={
+    "categorizer_cls": mask_fn_dl_orth_with_l1_seeds,
+})

--- a/law.cfg
+++ b/law.cfg
@@ -10,6 +10,9 @@ columnflow.tasks.cms.external
 columnflow.tasks.cms.inference
 hbw.tasks.{inspection,campaigns,ml,inference,postfit_plots,plotting,wrapper,union,optimization,corrections,yields}
 
+# add scale factor task COMMENT OUT BEFORE COMMITS
+# trigger.trigger_sf
+
 
 
 [logging]
@@ -41,6 +44,9 @@ weight_production_modules: hbw.weight.default
 ml_modules: hbw.ml.base, hbw.ml.derived.{sl,dl,sl_res}
 inference_modules: hbw.inference.{sl,dl,sl_res}
 
+# Add this to the production_modules to produce scale factors
+# , trigger.trigger_prod
+
 # namespace of all columnflow tasks
 cf_task_namespace: cf
 
@@ -66,6 +72,9 @@ log_array_function_runtime: False
 
 # Tasks for which outputs will be checked for non-finite values before saving them to disk
 check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation, cf.UniteColumns
+
+# check_finite_output fails for string trigger ids COMMENT OUT BEFORE COMMITS
+# check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.PrepareMLEvents, cf.MLEvaluation, cf.UniteColumns
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose input columns should be
 # checked (raising an exception) for overlaps between fields when created a merged input array

--- a/trigger/plot_efficiencies.py
+++ b/trigger/plot_efficiencies.py
@@ -1,0 +1,383 @@
+# coding: utf-8
+
+"""
+Plotting function for trigger efficiencies.
+Example call:
+
+law run cf.PlotVariables1D --config c22post \
+--selector dl1_no_trigger --selector-steps no_trigger \
+--producers event_weights,trigger_prod,pre_ml_cats,dl_ml_inputs \
+--categories sr__2e --variables mli_lep_pt-trig_ids \
+--processes hh_ggf_hbb_hww2l2nu_kl1_kt1,tt_dl \
+--plot-function trigger.plot_efficiencies.plot_efficiencies \
+--general-settings "bin_sel=Ele30_WPTight_Gsf;" \
+
+optional:
+--skip-ratio False --cms-label simpw \
+for unrolling, plots are unrolled in the second variable bin:
+--variables = mli_lep_pt-mli_lep2_pt-trig_ids \
+--general-settings "bin_sel=Ele30_WPTight_Gsf;,unrolling=1;2;3" \
+when used as plotting function for multiple weight producers (only one process possible):
+law run hbw.PlotVariablesMultiHistProducer
+--general-settings "bin_sel=Ele30_WPTight_Gsf;,multi_weight=True" \
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import law
+
+from columnflow.util import maybe_import
+from columnflow.plotting.plot_all import plot_all
+from columnflow.plotting.plot_util import (
+    prepare_style_config,
+    remove_residual_axis,
+    apply_variable_settings,
+    apply_process_settings,
+    apply_density,
+)
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+mpl = maybe_import("matplotlib")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+od = maybe_import("order")
+
+logger = law.logger.get_logger(__name__)
+
+
+def safe_div(num, den, default=0):
+    """
+    Safely divide two arrays, setting the result to a default value where the denominator is zero.
+    """
+    return np.where(
+        (num > 0) & (den > 0),
+        num / den,
+        default,
+    )
+
+
+def binom_int(num, den, confint=0.68):
+    """
+    calculates clopper-pearson error
+    """
+    from scipy.stats import beta
+    quant = (1 - confint) / 2.
+    low = beta.ppf(quant, num, den - num + 1)
+    high = beta.ppf(1 - quant, num + 1, den - num)
+
+    return (np.nan_to_num(low), np.where(np.isnan(high), 1, high))
+    # from hist.intervals import clopper_pearson_interval
+    # return clopper_pearson_interval(num=num, denom=den, coverage=confint)
+
+
+def calc_efficiency_errors(num, den, c):
+    """
+    Calculate the error on an efficiency given the numerator and denominator histograms.
+    """
+    if c > -10:
+        # Use the variance to scale the numerator and denominator to remove an average weight,
+        # this reduces the errors for rare processes to more realistic values
+        num_scale = np.nan_to_num(num.values() / num.variances(), nan=1)
+        den_scale = num_scale  # np.nan_to_num(den.values() / den.variances(), nan=1)
+    else:
+        num_scale = 1
+        den_scale = 1
+
+    efficiency = np.nan_to_num((num.values() * num_scale) / (den.values() * den_scale), nan=0, posinf=1, neginf=0)
+
+    if np.any(efficiency > 1):
+        logger.warning(
+            "Some efficiencies are greater than 1",
+        )
+    elif np.any(efficiency < 0):
+        logger.warning(
+            "Some efficiencies are less than 0",
+        )
+
+    band_low, band_high = binom_int(num.values() * num_scale, den.values() * den_scale)
+
+    error_low = np.asarray(efficiency - band_low)
+    error_high = np.asarray(band_high - efficiency)
+
+    # remove negative errors
+    if np.any(error_low < 0):
+        logger.warning("Some lower uncertainties are negative, setting them to zero")
+        error_low[error_low < 0] = 0
+    if np.any(error_high < 0):
+        logger.warning("Some upper uncertainties are negative, setting them to zero")
+        error_high[error_high < 0] = 0
+
+    # remove large errors in empty bins
+    error_low[efficiency == 0] = 0
+    error_high[efficiency == 0] = 0
+
+    # stacking errors
+    errors = np.concatenate(
+        (error_low.reshape(error_low.shape[0], 1), error_high.reshape(error_high.shape[0], 1)),
+        axis=1,
+    )
+    errors = errors.T
+
+    return errors
+
+
+def calc_ratio_uncertainty(efficiencies: dict, errors: dict):
+    """
+    Calculate the error on the scale factors using a gaussian error propagation.
+    """
+    # symmetrize errors
+    sym_errors = {}
+    for key, value in errors.items():
+        if value.ndim == 2 and value.shape[0] == 2:
+            sym_errors[key] = np.maximum(value[0], value[1])
+        else:
+            sym_errors[key] = np.maximum(value[..., 0, :], value[..., 1, :])
+
+    # combine errors
+    uncertainty = np.sqrt(
+        (sym_errors[0] / efficiencies[1]) ** 2 + (efficiencies[0] * sym_errors[1] / efficiencies[1] ** 2) ** 2
+    )
+
+    return np.nan_to_num(uncertainty, nan=0, posinf=1, neginf=0)
+
+
+def plot_efficiencies(
+    hists: OrderedDict,
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
+    style_config: dict | None = None,
+    density: bool | None = False,
+    shape_norm: bool = False,
+    yscale: str | None = None,
+    variable_settings: dict | None = None,
+    process_settings: dict | None = None,
+    **kwargs,
+) -> plt.Figure:
+    """
+    Plotting function for trigger efficiencies.
+    """
+
+    # multi_weight allows using the task hbw.PlotVariablesMultiHistProducer
+    # to plot the efficiencies of multiple weight producers,
+    # This only works for single processes!
+    if kwargs.get("multi_weight", False):
+        # take processes from the first weight producer (they should always be the same)
+        processes = list(list(hists.values())[0].keys())
+        if len(processes) > 1:
+            raise ValueError("multi_weight=True only works for single processes")
+
+        # merge over processes
+        for hist_producer, w_hists in hists.items():
+            hists[hist_producer] = sum(w_hists.values())
+
+    if not kwargs.get("multi_weight", False):
+        hists = apply_process_settings(hists, process_settings)[0]
+
+    variable_inst = variable_insts[0]
+    hists = apply_variable_settings(hists, variable_insts, variable_settings)[0]
+    hists = apply_density(hists, density)
+
+    plot_config = OrderedDict()
+
+    # setup style config
+    default_style_config = prepare_style_config(
+        config_inst, category_inst, variable_inst, density, shape_norm, yscale,
+    )
+
+    # switch trigger and processes when plotting efficiency of one trigger for multiple processes
+    proc_as_label = False
+
+    hists = remove_residual_axis(hists, "shift")
+    if len(hists.keys()) > 1:
+        if "bin_sel" in kwargs:
+            mask_bins = kwargs["bin_sel"]
+            if len(mask_bins) == 1:
+                legend_title = f"{mask_bins[0]}"
+                proc_as_label = True
+
+    # save efficiencies for ratio calculation
+    if not kwargs.get("skip_ratio", True):
+        efficiencies = {}
+        efficiency_sums = {}
+        errors = {}
+
+    count_key = 0
+    len_label = 0
+
+    # for unrolling efficiencies
+    subslices = kwargs.get("unroll", [None])
+    for subslice in subslices:
+        # loop over processeslabel
+        for proc_inst, myhist in hists.items():
+            # for unrolling efficiencies, unroll takes the number of the bin to plot
+            if "unroll" in kwargs:
+                myhist = myhist[:, int(subslice), :]
+
+            if not hasattr(proc_inst, 'label'):
+                proc_label = proc_inst
+            else:
+                proc_label = proc_inst.label
+
+            # get normalisation from first histogram (all events)
+            # TODO: this could be possibly be a CLI option
+
+            norm_hist = myhist[:, 0]
+
+            # plot config for the background distribution
+            if not kwargs.get("skip_background", False):
+
+                plot_config["hist_0"] = {
+                    "method": "draw_hist_twin",
+                    "hist": myhist[:, 0],
+                    "kwargs": {
+                        "norm": 1,
+                        "label": None,
+                        "color": "grey",
+                        "histtype": "fill",
+                        "alpha": 0.3,
+                    },
+                }
+
+            # plot config for the individual triggers
+            if "bin_sel" in kwargs:
+                mask_bins = kwargs["bin_sel"][:-1] if kwargs["bin_sel"][-1] == "" else kwargs["bin_sel"]
+            else:
+                mask_bins = myhist.axes[1]
+            for i in mask_bins:
+                if i == 0:
+                    continue
+
+                if proc_as_label:
+                    label = f"{proc_label}"
+                else:
+                    label_dict = {
+                        "mixed": r"$e\mu$ trigger",  # "mixed + ele&jet",
+                        "emu_dilep": "Dilepton triggers",
+                        "ee_dilep": "Dilepton triggers",
+                        "mm_dilep": "Dilepton triggers1",
+                        "emu_single": "Single lepton triggers",
+                        "ee_single": "Single lepton triggers",
+                        "mm_single": "Single lepton triggers",
+                        "single": "Single lepton triggers",
+                        "electron+jet": "Electron + Jet trigger",
+                        "emu_dilep+emu_single": "OR single lepton triggers",
+                        "ee_dilep+ee_single": "OR single lepton triggers",
+                        "mm_dilep+mm_single": "OR single lepton triggers",
+                        "emu_dilep+emu_single+emu_electronjet": "OR Electron + Jet trigger",
+                        "ee_dilep+ee_single+ee_electronjet": "OR Electron + Jet trigger",
+                        "mm_dilep+mm_single+mm_electronjet": "OR Electron + Jet trigger",
+                        "alt_mix": "mixed + ele115",
+                        "dilep+single+electronjet+alt_mix": "mixed + ele115 + ele&jet",
+                        "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65": "QuadPFJet",
+                    }
+                    if i in label_dict.keys():
+                        label = label_dict[i]
+                    else:
+                        label = i
+
+                if "unroll" in kwargs:
+                    label += f" (bin {subslice})"
+
+                # calculate efficiency
+                # this scaling here is not really necessary as it cancels out
+                if count_key >= -10:
+                    # label += ", scaled"
+                    num_scale = np.nan_to_num(myhist[:, hist.loc(i)].values() / myhist[:, hist.loc(i)].variances(), nan=1)  # noqa
+                    den_scale = num_scale  # np.nan_to_num(norm_hist.values() / norm_hist.variances(), nan=1)
+                else:
+                    num_scale = 1
+                    den_scale = 1
+                efficiency = np.nan_to_num((myhist[:, hist.loc(i)].values()*num_scale) / (norm_hist.values()*den_scale),  # noqa
+                                           nan=0, posinf=1, neginf=0
+                                           )
+                efficiency_sum = np.sum(myhist[:, hist.loc(i)].values()) / np.sum(norm_hist.values())
+                label += f" ({efficiency_sum:.3f})"
+                # calculate uncertainties
+                if kwargs.get("skip_errorbars", False):
+                    eff_err = None
+                else:
+                    eff_err = calc_efficiency_errors(myhist[:, hist.loc(i)], norm_hist, count_key)
+
+                plot_config[f"hist_{proc_label}_{label}"] = {
+                    "method": "draw_custom_errorbars",
+                    "hist": myhist[:, hist.loc(i)],
+                    "kwargs": {
+                        "y": efficiency,
+                        "yerr": eff_err,
+                        "label": r"$e\mu$ trigger" if label == "mixed" else f"{label}",
+                    },
+                }
+                len_label = max(len(label), len_label)
+
+                # calculate ratio of efficiencies
+                if not kwargs.get("skip_ratio", True):
+                    efficiencies[count_key] = efficiency
+                    efficiency_sums[count_key] = efficiency_sum
+                    errors[count_key] = eff_err
+                    count_key += 1
+                    if len(efficiencies) > 1:
+                        plot_config[f"hist_{proc_label}_{label}"]["ratio_kwargs"] = {
+                            "y": np.nan_to_num(efficiencies[0] / efficiencies[1], nan=1, posinf=1, neginf=1),
+                            "yerr": calc_ratio_uncertainty(efficiencies, errors),
+                            "label": f"{label}",
+                            # "annotate": f"alpha={efficiency_sums[0]/efficiency_sums[1]:.2f}",
+                        }
+                    # else:
+                    #    plot_config[f"hist_{proc_label}_{label}"]["ratio_kwargs"] = {
+                    #        "y": np.ones_like(efficiency),
+                    #        "yerr": None,
+                    #        "label": f"{label}",
+                    #    }
+
+            # set legend title to process name
+            if proc_as_label:
+                default_style_config["legend_cfg"]["title"] = legend_title
+            else:
+                if "title" in default_style_config["legend_cfg"]:
+                    if proc_label not in default_style_config["legend_cfg"]["title"]:
+                        default_style_config["legend_cfg"]["title"] += " & " + proc_label
+                else:
+                    default_style_config["legend_cfg"]["title"] = proc_label
+
+    # plot-function specific changes
+    default_style_config["ax_cfg"]["ylabel"] = "Efficiency"
+
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
+    if "xlim" in kwargs:
+        style_config["ax_cfg"]["xlim"] = kwargs["xlim"]
+
+    style_config["cms_label_cfg"]["fontsize"] = 21
+    style_config["ax_cfg"]["ylim"] = kwargs.get("ylim", (0, 1.5))
+    style_config["ax_cfg"]["yscale"] = kwargs.get("yscale", "linear")
+    style_config["rax_cfg"]["ylabel"] = "Ratio"
+    style_config["rax_cfg"]["ylim"] = kwargs.get("rax_ylim", (0.92, 1.08))
+
+    style_config["legend_cfg"]["title_fontsize"] = 23
+    if len_label > 30:
+        style_config["legend_cfg"]["fontsize"] = 12
+    elif len_label > 20:
+        style_config["legend_cfg"]["fontsize"] = 15
+    else:
+        style_config["legend_cfg"]["fontsize"] = 23
+    style_config["legend_cfg"]["ncols"] = 1
+    style_config["legend_cfg"]["reverse"] = False
+
+    grid_spec = {"left": 0.1, "right": 0.9, "top": 0.95, "bottom": 0.1}
+    style_config["gridspec_cfg"] = grid_spec
+
+    # fig, axs = plot_all(plot_config, style_config, **kwargs)
+
+    # axs[1].annotate(
+    #     fr"$\mathit{{\alpha}}$={efficiency_sums[0]/efficiency_sums[1]:.2f}",
+    #     xy=(0.9, 0.2),
+    #     xycoords="axes fraction",
+    #     ha="center",
+    #     va="center",
+    #     fontsize=20,
+    # )
+    return plot_all(plot_config, style_config, **kwargs)

--- a/trigger/plot_efficiencies2d.py
+++ b/trigger/plot_efficiencies2d.py
@@ -1,0 +1,328 @@
+# coding: utf-8
+
+"""
+Plot function to plot 2D efficiency plots
+
+law run cf.PlotVariables2D --version v1 --config c22pre \
+--selector trigger_sel \
+--producers event_weights,trigger_prod,trig_cats \
+--processes tt_dl \
+--variables ht-electron_pt-trig_bits_e \
+--general-settings "bin_sel=Ele30_WPTight_Gsf" \
+--plot-function trigger.plot_efficiencies2d.plot_efficiencies2d
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from functools import partial
+from unittest.mock import patch
+
+import law
+
+from columnflow.util import maybe_import
+from columnflow.plotting.plot_util import (
+    remove_residual_axis,
+    apply_variable_settings,
+    apply_process_settings,
+    apply_density_to_hists,
+    get_position,
+    reduce_with,
+)
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+mpl = maybe_import("matplotlib")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+od = maybe_import("order")
+mticker = maybe_import("matplotlib.ticker")
+
+logger = law.logger.get_logger(__name__)
+
+
+def plot_efficiencies2d(
+    hists: OrderedDict,
+    config_inst: od.Config,
+    category_inst: od.Category,
+    variable_insts: list[od.Variable],
+    style_config: dict | None = None,
+    density: bool | None = False,
+    shape_norm: bool | None = False,
+    zscale: str | None = "",
+    # z axis range
+    zlim: tuple | None = None,
+    # how to handle bins with values outside the z range
+    extremes: str | None = "",
+    # colors to use for marking out-of-bounds values
+    extreme_colors: tuple[str] | None = None,
+    colormap: str | None = "",
+    skip_legend: bool = False,
+    cms_label: str = "wip",
+    process_settings: dict | None = None,
+    variable_settings: dict | None = None,
+    **kwargs,
+) -> plt.Figure:
+    # remove shift axis from histograms
+    remove_residual_axis(hists, "shift")
+
+    hists = apply_variable_settings(hists, variable_insts, variable_settings)
+
+    hists = apply_process_settings(hists, process_settings)
+
+    hists = apply_density_to_hists(hists, density)
+
+    # use CMS plotting style
+    plt.style.use(mplhep.style.CMS)
+    fig, ax = plt.subplots()
+
+    # how to handle yscale information from 2 variable insts?
+    if not zscale:
+        zscale = "log" if (variable_insts[0].log_y or variable_insts[1].log_y) else "linear"
+
+    # how to handle bin values outside plot range
+    if not extremes:
+        extremes = "color"
+
+    # add all processes into 1 histogram
+    h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
+
+    # calculate efficiencies
+    eff_bin = kwargs.get("bin_sel", 0)
+
+    if eff_bin == 0:
+        logger.warning(
+            "No bin selected, bin zero is used for efficiency calculation",
+        )
+
+    h2d_trig = h_sum[:, :, eff_bin].values()
+    hh2d_all = h_sum[:, :, 0].values()
+
+    eff_2d = h2d_trig / hh2d_all  # hh2d_all was previously commented out, but in general should be needed here
+
+    if np.any(eff_2d > 1):
+        logger.warning(
+            "Some efficiencies are greater than 1",
+        )
+    elif np.any(eff_2d < 0):
+        logger.warning(
+            "Some efficiencies are less than 0",
+        )
+
+    # either plot the efficiency directly or as a contour plot over a background distribution
+    if kwargs.get("contour", False):
+        h_view = h_sum[:, :, 0]
+        h_eff = hist.Hist(*h_sum[:, :, 0].axes, data=eff_2d)
+    else:
+        h_view = hist.Hist(*h_sum[:, :, 0].axes, data=eff_2d)
+
+    # check histogram value range
+    vmin, vmax = np.nanmin(h_view.values()), np.nanmax(h_view.values())
+    vmin, vmax = np.nan_to_num(np.array([vmin, vmax]), 0)
+
+    # default to full z range
+    if zlim is None:
+        zlim = (0, 1)
+
+    # resolve string specifiers like "min", "max", etc.
+    zlim = tuple(reduce_with(lim, h_view.values()) for lim in zlim)
+
+    # if requested, hide or clip bins outside specified plot range
+    if extremes == "hide":
+        h_view.values()[h_view.values() < zlim[0]] = np.nan
+        h_view.values()[h_view.values() > zlim[1]] = np.nan
+    elif extremes == "clip":
+        h_view.values()[h_view.values() < zlim[0]] = zlim[0]
+        h_view.values()[h_view.values() > zlim[1]] = zlim[1]
+
+    # update histogram values from view
+    h_sum = h_view
+
+    # choose appropriate colorbar normalization
+    # based on scale type and histogram content
+
+    # log scale (turning linear for low values)
+    if zscale == "log":
+        # use SymLogNorm to correctly handle both positive and negative values
+        cbar_norm = mpl.colors.SymLogNorm(
+            vmin=zlim[0],
+            vmax=zlim[1],
+            # TODO: better heuristics?
+            linscale=1.0,
+            linthresh=max(0.05 * min(abs(zlim[0]), abs(zlim[1])), 1e-3),
+        )
+
+    # linear scale
+    else:
+        cbar_norm = mpl.colors.Normalize(
+            vmin=zlim[0],
+            vmax=zlim[1],
+        )
+
+    # obtain colormap
+    cmap = plt.get_cmap(colormap or "viridis")
+
+    # use dark and light gray to mark extreme values
+    if extremes == "color":
+        # choose light/dark order depending on the
+        # lightness of first/last colormap color
+        if not extreme_colors:
+            extreme_colors = ["#444444", "#bbbbbb"]
+            if sum(cmap(0.0)[:3]) > sum(cmap(1.0)[:3]):
+                extreme_colors = extreme_colors[::-1]
+
+        # copy if colormap with extreme colors set
+        cmap = cmap.with_extremes(
+            under=extreme_colors[0],
+            over=extreme_colors[1],
+        )
+
+    # setup style config
+    # TODO: some kind of z-label is still missing
+    default_style_config = {
+        "ax_cfg": {
+            "xlim": (variable_insts[0].x_min, variable_insts[0].x_max),
+            "ylim": (variable_insts[1].x_min, variable_insts[1].x_max),
+            "xlabel": variable_insts[0].get_full_x_title(),
+            "ylabel": variable_insts[1].get_full_x_title(),
+            "xscale": "log" if variable_insts[0].log_x else "linear",
+            "yscale": "log" if variable_insts[1].log_x else "linear",
+        },
+        "legend_cfg": {
+            # "title": "Process" if len(hists.keys()) == 1 else "Processes",
+            "handles": [mpl.lines.Line2D([0], [0], lw=0) for proc_inst in hists.keys()],  # dummy handle
+            "labels": [f"Process:\n {proc_inst.label}\nTrigger:\n HLT_{eff_bin}" for proc_inst in hists.keys()],
+            "ncol": 1,
+            "loc": "upper right",
+            # "labelcolor": "white",
+        },
+        "cms_label_cfg": {
+            "lumi": config_inst.x.luminosity.get("nominal") / 1000,  # pb -> fb
+            "com": config_inst.campaign.ecm,
+        },
+        "plot2d_cfg": {
+            "norm": cbar_norm,
+            "cmap": cmap,
+            # "labels": True,  # this enables displaying numerical values for each bin, but needs some optimization
+            "cbar": True,
+            "cbarextend": True,
+        },
+        "annotate_cfg": {
+            "text": category_inst.label,
+        },
+    }
+    style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
+
+    # apply style_configmin
+    ax.set(**style_config["ax_cfg"])
+    if not skip_legend:
+        ax.legend(**style_config["legend_cfg"])
+
+    if variable_insts[0].discrete_x:
+        ax.set_xticks([], minor=True)
+    if variable_insts[1].discrete_x:
+        ax.set_yticks([], minor=True)
+
+    # annotation of category label
+    annotate_kwargs = {
+        "text": "",
+        "xy": (
+            get_position(*ax.get_xlim(), factor=0.05, logscale=False),
+            get_position(*ax.get_ylim(), factor=0.95, logscale=False),
+        ),
+        "xycoords": "data",
+        "color": "black",
+        "fontsize": 22,
+        "horizontalalignment": "left",
+        "verticalalignment": "top",
+    }
+    annotate_kwargs.update(default_style_config.get("annotate_cfg", {}))
+    plt.annotate(**annotate_kwargs)
+
+    # cms label
+    if cms_label != "skip":
+        label_options = {
+            "wip": "Work in progress",
+            "pre": "Preliminary",
+            "pw": "Private work",
+            "sim": "Simulation",
+            "simwip": "Simulation work in progress",
+            "simpre": "Simulation preliminary",
+            "simpw": "Simulation private work",
+            "od": "OpenData",
+            "odwip": "OpenData work in progress",
+            "odpw": "OpenData private work",
+            "public": "",
+        }
+        if cms_label == "pw":
+            cms_label_kwargs = {
+                "ax": ax,
+                "llabel": "Private work (CMS Simulation)",
+                "fontsize": 22,
+                "data": False,
+                "exp": "",
+            }
+        else:
+            cms_label_kwargs = {
+                "ax": ax,
+                "llabel": label_options.get(cms_label, cms_label),
+                "fontsize": 22,
+                "data": False,
+            }
+
+        cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
+        mplhep.cms.label(**cms_label_kwargs)
+
+    # decide at which ends of the colorbar to draw symbols
+    # indicating that there are values outside the range
+    if extremes == "hide":
+        extend = "neither"
+    elif vmax > zlim[1] and vmin < zlim[0]:
+        extend = "both"
+    elif vmin < zlim[0]:
+        extend = "min"
+    elif vmax > zlim[1]:
+        extend = "max"
+    else:
+        extend = "neither"
+
+    # call plot method, patching the colorbar function
+    # called internally by mplhep to draw the extension symbols
+    with patch.object(plt, "colorbar", partial(plt.colorbar, extend=extend)):
+        h_sum.plot2d(ax=ax, **style_config["plot2d_cfg"])
+
+    # ax.collections[0].colorbar.set_label("Efficiency", fontsize=22, labelpad=20)
+
+    # add contour lines, if requested smoothed
+    if kwargs.get("contour", False):
+        from scipy.ndimage.filters import gaussian_filter
+        cs = ax.contour(
+            h_eff.axes.centers[0].flatten(), h_eff.axes.centers[1].flatten(),
+            gaussian_filter(h_eff.values(), kwargs.get("sigma", 0)),
+            cmap="Oranges_r", levels=[0, .1, .2, .5, .7, .8, .9, 1],
+        )
+
+        ax.clabel(cs, cs.levels, inline=True, fontsize=10)
+
+    # fix color bar minor ticks with SymLogNorm
+    if isinstance(cbar_norm, mpl.colors.SymLogNorm):
+        # returned collections can vary -> brute-force set
+        # norm on all colorbars that are found
+        cbars = {
+            coll.colorbar
+            for coll in ax.collections
+            if coll.colorbar
+        }
+        for cbar in cbars:
+            _scale = cbar.ax.yaxis._scale
+            _scale.subs = [2, 3, 4, 5, 6, 7, 8, 9]
+            cbar.ax.yaxis.set_minor_locator(
+                mticker.SymmetricalLogLocator(_scale.get_transform(), subs=_scale.subs),
+            )
+            cbar.ax.yaxis.set_minor_formatter(
+                mticker.LogFormatterSciNotation(_scale.base),
+            )
+
+    plt.tight_layout()
+
+    return fig, (ax,)

--- a/trigger/trigger_cats.py
+++ b/trigger/trigger_cats.py
@@ -1,0 +1,60 @@
+# coding: utf-8
+
+"""
+Categorizers to apply additional cuts when building histograms, e.g. applying an orthogonal trigger
+"""
+
+from __future__ import annotations
+
+from columnflow.util import maybe_import
+from columnflow.categorization import Categorizer, categorizer
+# from columnflow.selection import SelectionResult
+# from columnflow.columnar_util import has_ak_column, optional_column
+#
+# from hbw.util import MET_COLUMN, BTAG_COLUMN
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+def check_l1_seeds(self: Categorizer, events: ak.Array, trigger) -> ak.Array:
+    """
+    Check if the unprescaled L1 seeds of a given trigger have fired
+    """
+    l1_seeds_fired = ak.Array([False] * len(events))
+
+    for l1_seed in self.config_inst.x.hlt_L1_seeds[trigger]:
+        l1_seeds_fired = l1_seeds_fired | events.L1[l1_seed]
+
+    return l1_seeds_fired
+
+
+########################################################################################################################
+# Mask functions for dilepton channel
+########################################################################################################################
+# TODO: Using these deferred functions like MET_COlUMN this could probably done more flexible for all channels
+@categorizer()
+def mask_fn_dl_orth_with_l1_seeds(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    """
+    Applies the orthogonal trigger for the dilepton channel, checking if the L1 seeds have fired
+    """
+
+    trigger_fired = events.HLT[self.config_inst.x.dl_orthogonal_trigger]
+    l1_seeds_fired = check_l1_seeds(self, events, self.config_inst.x.dl_orthogonal_trigger)
+
+    mask = trigger_fired & l1_seeds_fired
+
+    return events, mask
+
+
+@mask_fn_dl_orth_with_l1_seeds.init
+def mask_fn_dl_orth_with_l1_seeds_init(self: Categorizer) -> None:
+    """
+    Add HLT and L1 columns for the orthogonal trigger
+    """
+    if not self.config_inst.x.dl_orthogonal_trigger or not self.config_inst.x.hlt_L1_seeds:
+        raise ValueError("No orthogonal trigger or associated L1 seeds set for dilepton channel")
+
+    self.uses.add(f"HLT.{self.config_inst.x.dl_orthogonal_trigger}")
+    for l1_seed in self.config_inst.x.hlt_L1_seeds[self.config_inst.x.dl_orthogonal_trigger]:
+        self.uses.add(f"L1.{l1_seed}")

--- a/trigger/trigger_prod.py
+++ b/trigger/trigger_prod.py
@@ -1,0 +1,445 @@
+# coding: utf-8
+
+"""
+Column production methods related trigger studies
+"""
+
+
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
+
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+########################################################################################################################
+# Single lepton trigger producer
+########################################################################################################################
+
+# produce trigger columns for single lepton channel
+@producer(
+    produces={"trig_ids"},
+    channel=["m", "e"],
+    version=10,
+)
+def trigger_prod_sl(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Produces column filled for each event with the triggers triggering the event.
+    This column can then be used to fill a Histogram where each bin corresponds to a certain trigger.
+    This producer is only to explore the different possible triggers and their combinations.
+    """
+
+    # TODO: check if trigger were fired by unprescaled L1 seed
+    trig_ids = ak.Array([["allEvents"]] * len(events))
+
+    for channel in self.channel:
+        # add individual triggers
+        for trigger in self.config_inst.x.sl_triggers[f"{self.config_inst.x.year}"][channel]:
+            if not ak.any(trig_ids == trigger):  # avoid double counting
+                trig_passed = ak.where(events.HLT[trigger], [[trigger]], [[]])
+                trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    combinations22 = {
+        "ele30ele28": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150"
+        ],
+        "ele30_quadjet": [
+            "Ele30_WPTight_Gsf",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ],
+        "ele30e28e15": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450"
+        ],
+        "ele30e28e15_quadjet": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ],
+        "ele30e15_quadjet": [
+            "Ele30_WPTight_Gsf",
+            "Ele15_IsoVVVL_PFHT450",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ],
+        "ele30e28e15e50_quadjet": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ],
+        "mu24m50": [
+            "IsoMu24",
+            "Mu50"
+        ],
+        "mu24m50_quadjet": [
+            "IsoMu24",
+            "Mu50",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ],
+        "mu24m50m15_quadjet": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65"
+        ]
+    }
+    combinations23 = {
+        "e30e28": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+        ],
+        "e30e28e15": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+        ],
+        "e30e28e15e50": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165"
+        ],
+        "e30e28e15e50_quad340": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "e30e28e15e50_quad280": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "exEle30": [
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "exEle28": [
+            "Ele30_WPTight_Gsf",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "exEle15": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "exEle50": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "exeQuad280": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+        ],
+        "exeQuad340": [
+            "Ele30_WPTight_Gsf",
+            "Ele28_eta2p1_WPTight_Gsf_HT150",
+            "Ele15_IsoVVVL_PFHT450",
+            "Ele50_CaloIdVT_GsfTrkIdT_PFJet165",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+        ],
+        "m24m50": [
+            "IsoMu24",
+            "Mu50"
+        ],
+        "m24m50_quad340": [
+            "IsoMu24",
+            "Mu50",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "m24m50_quad280": [
+            "IsoMu24",
+            "Mu50",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "m24m50m15_quad280": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55"
+        ],
+        "m24m50m15_quad340": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "m24m50m15_quad280_340": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "m24m50m15_quad280_340_Mu3MET": [
+            "IsoMu24",
+            "Mu50",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+            "Mu3er1p5_PFJet100er2p5_PFMETNoMu100_PFMHTNoMu100_IDTight"
+        ],
+        "exIsoMu24": [
+            "Mu50",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "exMu50": [
+            "IsoMu24",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "exMu15": [
+            "IsoMu24",
+            "Mu50",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"
+        ],
+        "exQuad280": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70",
+        ],
+        "exQuad340": [
+            "IsoMu24",
+            "Mu50",
+            "Mu15_IsoVVVL_PFHT450",
+            "PFHT280_QuadPFJet30_PNet2BTagMean0p55",
+        ],
+    }
+    combinations = {
+        2022: combinations22,
+        2023: combinations23
+    }
+
+    for key in combinations[self.config_inst.x.year].keys():
+        trig_passed = ak.Array([0] * len(events))
+        for trigger in combinations[self.config_inst.x.year][key]:
+            trig_passed = trig_passed | (events.HLT[trigger])
+        trig_passed = ak.where(trig_passed, [[key]], [[]])
+        trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    events = set_ak_column(events, "trig_ids", trig_ids)
+
+    return events
+
+
+# initialize the trigger producer, triggers can be set in the trigger config
+@trigger_prod_sl.init
+def trigger_prod_sl_init(self: Producer) -> None:
+
+    for channel in self.config_inst.x.sl_triggers[f"{self.config_inst.x.year}"]:
+        for trigger in self.config_inst.x.sl_triggers[f"{self.config_inst.x.year}"][channel]:
+            self.uses.add(f"HLT.{trigger}")
+
+
+########################################################################################################################
+# Dilepton trigger producer
+########################################################################################################################
+
+# dilepton trigger prod
+@producer(
+    produces={"trig_ids"},
+    version=1,
+)
+def trigger_prod_dl(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Uses the trigger_ids produced during the selection to build additional combinations of triggers.
+    Produces column filled for each event with the triggers triggering the event.
+    This column can then be used to fill a Histogram where each bin corresponds to a certain trigger.
+    """
+    # build sequential combinations of triggers, ids can be found in the trigger config
+    mixed_trigger_sequence = {
+        "emu_dilep": [301, 401],
+        "emu_single": [201, 101],
+        "emu_electronjet": [203],
+    }
+    ee_trigger_sequence = {
+        "ee_dilep": [202, 204],
+        "ee_single": [201],
+        "ee_electronjet": [203],
+    }
+    mm_trigger_sequence = {
+        "mm_dilep": [102],
+        "mm_single": [101],
+    }
+    trigger_sequence = {
+        "ee": ee_trigger_sequence,
+        "mm": mm_trigger_sequence,
+        "mixed": mixed_trigger_sequence
+    }
+
+    # initialize the trigger ids column filled with the labels
+    trig_ids = ak.Array([["allEvents"]] * len(events))
+    # add individual triggers
+    for trigger in self.config_inst.x.triggers:
+        trig_passed = ak.any(events.trigger_ids == trigger.id, axis=1)
+        trig_ids = ak.concatenate([trig_ids, ak.where(trig_passed, [[trigger.hlt_field]], [[]])], axis=1)
+
+    # add sequential combinations of triggers
+    for channel in ["ee", "mm", "mixed"]:
+        seq_trigger = events.run * 0  # initialize with zeros
+        seq_label = ""
+        for label, trigger_ids in trigger_sequence[channel].items():
+            trigger_mask = events.run * 0
+            for trigger_id in trigger_ids:
+                trigger_mask = trigger_mask | ak.any(events.trigger_ids == trigger_id, axis=1)
+                seq_trigger = seq_trigger | ak.any(events.trigger_ids == trigger_id, axis=1)
+
+            trig_passed = ak.where(trigger_mask, [[label]], [[]])
+            trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+            seq_label += label + "+"
+            if "+" in seq_label[:-1]:
+                trig_passed = ak.where(seq_trigger, [[seq_label[:-1]]], [[]])
+                trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+        # add the complete channel selection
+        trig_passed = ak.where(seq_trigger, [[f"{channel}"]], [[]])
+        trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    events = set_ak_column(events, "trig_ids", trig_ids)
+
+    return events
+
+
+# initialize the dilepton trigger producer, triggers can be set in the trigger config
+@trigger_prod_dl.init
+def trigger_prod_dl_init(self: Producer) -> None:
+    self.uses.add("trigger_ids")
+
+
+# dilepton trigger prod without sequential combinations to reduce memory usage
+@producer(
+    produces={"trig_ids"},
+    version=1,
+)
+def trigger_prod_dls(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Uses the trigger_ids produced during the selection to build additional combinations of triggers.
+    Produces column filled for each event with the triggers triggering the event.
+    This column can then be used to fill a Histogram where each bin corresponds to a certain trigger.
+    """
+    # build sequential combinations of triggers, ids can be found in the trigger config
+    mixed_trigger_sequence = {
+        "emu_dilep": [301, 401],
+        "emu_single": [201, 101],
+        "emu_electronjet": [203],
+    }
+    ee_trigger_sequence = {
+        "ee_dilep": [202, 204],
+        "ee_single": [201],
+        "ee_electronjet": [203],
+    }
+    mm_trigger_sequence = {
+        "mm_dilep": [102],
+        "mm_single": [101],
+    }
+    trigger_sequence = {
+        "ee": ee_trigger_sequence,
+        "mm": mm_trigger_sequence,
+        "mixed": mixed_trigger_sequence
+    }
+
+    # initialize the trigger ids column filled with the labels
+    trig_ids = ak.Array([["allEvents"]] * len(events))
+    # add individual triggers
+    for trigger in self.config_inst.x.triggers:
+        trig_passed = ak.any(events.trigger_ids == trigger.id, axis=1)
+        trig_ids = ak.concatenate([trig_ids, ak.where(trig_passed, [[trigger.hlt_field]], [[]])], axis=1)
+
+    # add sequential combinations of triggers
+    for channel in ["ee", "mm", "mixed"]:
+        seq_trigger = events.run * 0  # initialize with zeros
+        seq_label = ""
+        for label, trigger_ids in trigger_sequence[channel].items():
+            trigger_mask = events.run * 0
+            for trigger_id in trigger_ids:
+                trigger_mask = trigger_mask | ak.any(events.trigger_ids == trigger_id, axis=1)
+                seq_trigger = seq_trigger | ak.any(events.trigger_ids == trigger_id, axis=1)
+
+            # trig_passed = ak.where(trigger_mask, [[label]], [[]])
+            # trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+            seq_label += label + "+"
+            # if "+" in seq_label[:-1]:
+            #     # trig_passed = ak.where(seq_trigger, [[seq_label[:-1]]], [[]])
+            #     # trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+        # add the complete channel selection
+        trig_passed = ak.where(seq_trigger, [[f"{channel}"]], [[]])
+        trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    events = set_ak_column(events, "trig_ids", trig_ids)
+
+    return events
+
+
+# initialize the dilepton trigger producer, triggers can be set in the trigger config
+@trigger_prod_dls.init
+def trigger_prod_dls_init(self: Producer) -> None:
+    self.uses.add("trigger_ids")
+
+
+########################################################################################################################
+# Simple trigger producer for debugging
+########################################################################################################################
+
+# produce trigger columns for debugging
+@producer(
+    produces={"trig_ids"},
+    channel=["mm", "ee", "mixed"],
+    version=1,
+)
+def trigger_prod_db(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Produces column filled for each event with the triggers triggering the event.
+    This column can then be used to fill a Histogram where each bin corresponds to a certain trigger.
+    """
+
+    trig_ids = ak.Array([["allEvents"]] * len(events))
+
+    # add individual triggers
+    for trigger in self.config_inst.x.triggers:
+        trig_passed = ak.where(events.HLT[trigger.hlt_field], [[trigger.hlt_field]], [[]])
+        trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    trig_ids = ak.concatenate([trig_ids, trig_passed], axis=1)
+
+    events = set_ak_column(events, "trig_ids", trig_ids)
+
+    return events
+
+
+# initialize the trigger producer, triggers can be set in the trigger config
+@trigger_prod_db.init
+def trigger_prod_db_init(self: Producer) -> None:
+
+    for trigger in self.config_inst.x("triggers", []):
+        self.uses.add(f"HLT.{trigger.hlt_field}")

--- a/trigger/trigger_sf.py
+++ b/trigger/trigger_sf.py
@@ -1,0 +1,600 @@
+# coding: utf-8
+
+"""
+Tasks to calculate and save trigger scale factors.
+"""
+
+from __future__ import annotations
+
+import luigi
+import law
+import order as od
+
+from columnflow.tasks.framework.base import Requirements
+from columnflow.util import maybe_import, DotDict
+from columnflow.tasks.framework.histograms import (
+    HistogramsUserSingleShiftBase,
+)
+from columnflow.tasks.framework.parameters import MultiSettingsParameter
+from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.histograms import MergeHistograms
+from columnflow.plotting.plot_util import use_flow_bins
+
+from hbw.config.hist_hooks import rebin_hist
+from trigger.trigger_util import (
+    calculate_efficiencies,
+    calc_sf_uncertainty,
+    optimise_binning1d,
+    optimise_binning2d,
+)
+
+logger = law.logger.get_logger(__name__)
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+scipy = maybe_import("scipy")
+mpl = maybe_import("matplotlib")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+
+
+class CalculateTriggerScaleFactors(
+    HistogramsUserSingleShiftBase,
+):
+    """
+    Loads histograms containing the trigger informations for data and MC and calculates the trigger scale factors.
+    """
+
+    trigger = luigi.Parameter(
+        default="allEvents",
+        description="The trigger to calculate the scale factors for, must be set; default: allEvents",
+    )
+
+    hist_producers = law.CSVParameter(
+        default=("default",),
+        description="Weight producers to use for plotting",
+    )
+
+    variable_settings = MultiSettingsParameter(
+        default=DotDict(),
+        significant=False,
+        description="parameter for changing different variable settings; format: "
+        "'var1,option1=value1,option3=value3:var2,option2=value2'; options implemented: "
+        "rebin; can also be the key of a mapping defined in 'variable_settings_groups; "
+        "default: value of the 'default_variable_settings' if defined, else empty default",
+        brace_expand=True,
+    )
+
+    bins_optimised = luigi.BoolParameter(
+        default=True,
+        description="Optimise the binning to get relative uncertainties below 5%",
+    )
+
+    suffix = luigi.Parameter(
+        default="",
+        description="Suffix to append to the output file names",
+    )
+
+    premade_edges = luigi.BoolParameter(
+        default=False,
+        description="Use premade bin edges for the optimisation",
+    )
+
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
+        MergeHistograms=MergeHistograms,
+    )
+
+    def requires(self):
+        return {
+            hist_producer: {
+                d: self.reqs.MergeHistograms.req(
+                    self,
+                    dataset=d,
+                    branch=-1,
+                    hist_producer=hist_producer,
+                    _exclude={"branches"},
+                    _prefer_cli={"variables"},
+                )
+                for d in self.datasets
+            }
+            for hist_producer in self.hist_producers
+        }
+
+    @property
+    def hist_producers_repr(self):
+        return "_".join(self.hist_producers)
+
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "weights", f"weights_{self.hist_producers_repr}")
+        return parts
+
+    def load_histogram(
+        self,
+        hist_producer: str,
+        dataset: str | od.Dataset,
+        variable: str | od.Variable,
+    ) -> hist.Hist:
+        """
+        Helper function to load the histogram from the input for a given dataset and variable.
+
+        :param hist_producer: The weight producer name.
+        :param dataset: The dataset name or instance.
+        :param variable: The variable name or instance.
+        :return: The loaded histogram.
+        """
+        if isinstance(dataset, od.Dataset):
+            dataset = dataset.name
+        if isinstance(variable, od.Variable):
+            variable = variable.name
+        histogram = self.input()[hist_producer][dataset]["collection"][0]["hists"].targets[variable].load(formatter="pickle")  # noqa
+        return histogram
+
+    def calc_sf_and_unc(
+        self,
+        hists: dict,
+        envelope: bool = False,
+    ):
+        """
+        Calculate the trigger scale factors and their uncertainties.
+        Also returns the efficiencies and their uncertainties used in the calculation.
+        """
+        efficiencies = {
+            self.hist_producers[0]: {},
+            self.hist_producers[1]: {},
+        }
+        efficiency_unc = {
+            self.hist_producers[0]: {},
+            self.hist_producers[1]: {},
+        }
+
+        sf_envelope = {
+            "up": {},
+            "down": {},
+        }
+        sf_diff = {}
+
+        # calc sfs for different categories
+        if not envelope:
+            # get half point
+            axes = hists[self.hist_producers[1]][self.variables[0]].axes.name
+            h2 = hists[self.hist_producers[1]][self.variables[0]][{"process": 0}]
+            for var in axes:
+                if "npvs" not in var and "process" not in var:
+                    h2 = h2[{var: sum}]
+
+                half_point = int(np.where(np.cumsum(h2.values()) >= (np.sum(h2.values()) / 2))[0][0])
+                self.half_point = half_point
+
+            for region in sf_envelope.keys():
+                slice_borders = {
+                    "down": (0, half_point),
+                    "up": (half_point, len(h2.values())),
+                }
+                hists2 = {
+                    self.hist_producers[0]: {},
+                    self.hist_producers[1]: {},
+                }
+                for hist_producer in self.hist_producers:
+                    h1 = hists[hist_producer][self.variables[0]][{
+                        "npvs": slice(slice_borders[region][0], slice_borders[region][1])}]
+                    hists2[hist_producer][self.variables[0]] = h1[:, :, 0:len(h1[0, 0, :, 0].values()):sum, :]
+
+                sf_envelope[region], _, _, _ = self.calc_sf_and_unc(hists2, envelope=True)
+
+            for hist_producer in self.hist_producers:
+                hists[hist_producer][self.variables[0]] = hists[hist_producer][self.variables[0]][{"npvs": sum}]
+
+        for hist_producer in self.hist_producers:
+            # calculate efficiencies. process, shift, variable, bin
+            efficiencies[hist_producer], efficiency_unc[hist_producer] = calculate_efficiencies(
+                hists[hist_producer][self.variables[0]][:, ..., :], self.trigger
+            )
+
+        # calculate scale factors, second weight producer is used
+        scale_factors = np.nan_to_num(
+            efficiencies[self.hist_producers[1]][0] / efficiencies[self.hist_producers[1]][1],
+            nan=1,
+            posinf=1,
+            neginf=1,
+        )
+        scale_factors[scale_factors == 0] = 1
+        # calculate alpha factors
+        alpha_factors = np.nan_to_num(
+            efficiencies[self.hist_producers[0]][1] / efficiencies[self.hist_producers[1]][1],
+            nan=1,
+            posinf=1,
+            neginf=1,
+        )
+
+        # only use the efficiencies and uncertainties of the second weight producer
+        efficiencies = efficiencies[self.hist_producers[1]]
+        efficiency_unc = efficiency_unc[self.hist_producers[1]]
+        # calculate scale factor uncertainties, only statistical uncertainties are considered right now
+        uncertainties = calc_sf_uncertainty(
+            efficiencies, efficiency_unc, alpha_factors
+        )
+
+        if not envelope:
+            # symmetrise the envelope
+            for key, sf in sf_envelope.items():
+                sf_diff[key] = np.abs(scale_factors - sf)
+
+            sf_env_unc = np.maximum(sf_diff["up"], sf_diff["down"])
+
+            unc_with_sf_env = np.sqrt(uncertainties**2 + sf_env_unc**2)
+
+        if envelope:
+            return scale_factors, uncertainties, efficiencies, efficiency_unc
+        else:
+            return scale_factors, uncertainties, efficiencies, efficiency_unc, sf_env_unc, unc_with_sf_env, alpha_factors, sf_envelope  # noqa
+
+    def output(self):
+        return {
+            "trigger_scale_factors": self.target(f"sf_{self.trigger}_{self.variables[0]}{self.suffix}.json"),
+            "trigger_sf_plot":
+            self.target(f"{self.categories[0]}_{self.trigger}_{self.variables[0]}_sf_plot{self.suffix}.pdf"),
+        }
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        reqs["merged_hists"] = self.requires_from_branch()
+
+        return reqs
+
+    def run(self):
+        import correctionlib
+        import correctionlib.convert
+
+        outputs = self.output()
+
+        hists = {
+            self.hist_producers[0]: {},
+            self.hist_producers[1]: {},
+        }
+
+
+        edges1p2 = [0., 15., 25., 35., 44., 51., 57., 64., 80., 110., 240.] # noqa
+        edges2p1 = [0., 15., 25., 35., 64., 240.] # noqa
+
+        mmedges1p1 = [  0., 15., 25.,  37.,  47.,  55.,  66.,  81.,  96., 111., 146., 240.] # noqa
+        mmedges2p1 = [  0.,  15.,  28.,  37.,  47., 240.] # noqa
+
+        mixedges1 = [0., 15., 25., 35., 46., 56., 67., 80., 95., 168., 240.]
+        mixedges2 = [0., 15., 25., 35., 46., 240.]
+
+        edgesee = {"lepton0_pt": edges1p2, "lepton1_pt": edges2p1}
+        edgesmu = {"lepton0_pt": mmedges1p1, "lepton1_pt": mmedges2p1}
+        edgesmix = {"lepton0_pt": mixedges1, "lepton1_pt": mixedges2}
+        pre_edges = {"ee": edgesee, "mm": edgesmu, "mixed": edgesmix}
+
+        for hist_producer in self.hist_producers:
+            for dataset in self.datasets:
+                for variable in self.variables:
+                    h_in = self.load_histogram(hist_producer, dataset, variable)
+                    h_in = self.slice_histogram(h_in, self.processes, self.categories, self.shift)
+                    h_in = h_in[{"category": sum}]
+                    h_in = h_in[{"shift": sum}]
+                    for var in self.variable_settings:
+                        if var in h_in.axes.name:
+                            # use over and underflow bins unless specified otherwise
+                            if self.variable_settings[var].get("use_flow_bins", True):
+                                h_in = use_flow_bins(h_in, var)
+                            # rebin if specified
+                            if "rebin" in self.variable_settings[var]:
+                                h_in = h_in[{var: hist.rebin(int(self.variable_settings[var]["rebin"]))}]
+                        else:
+                            logger.warning(f"Variable {var} not found in histogram, skipping rebinning")
+                    if self.premade_edges:
+                        for var in h_in.axes.name[1:3]:
+                            h_in = rebin_hist(h_in, var, pre_edges[self.trigger][var])
+                    if variable in hists[hist_producer].keys():
+                        hists[hist_producer][variable] += h_in
+                    else:
+                        hists[hist_producer][variable] = h_in
+
+        from hbw.util import debugger
+        debugger()
+        old_axes = hists[self.hist_producers[0]][self.variables[0]][0, ..., 0].axes
+
+        # optimise 1d binning
+        if len(self.variables[0].split("-")[:-1]) == 1:
+
+            if not self.bins_optimised:
+
+                hists, _ = optimise_binning1d(
+                    calculator=self,
+                    hists=hists,
+                    target_uncertainty=0.05,
+                )
+
+                self.bins_optimised = True
+
+        elif len(self.variables[0].split("-")[:-1]) > 2 and not self.bins_optimised:
+            logger.warning(
+                "Binning optimisation not implemented for histograms with more than 2 dimensions, using default binning"
+            )
+            self.bins_optimised = True
+
+        # normal procedure for optimised binning, sf_envelope, unc_with_sf_env
+        if self.bins_optimised:
+
+            # scale_factors, uncertainties, efficiencies, efficiency_unc, sf_env_unc, unc_with_sf_env, alpha_factors, sf_envelope = self.calc_sf_and_unc(hists, envelope=False)  # noqa
+            scale_factors, uncertainties, efficiencies, efficiency_unc = self.calc_sf_and_unc(hists, envelope=True)  # noqa
+            scale_factors[uncertainties == 0.0] = 1.0
+
+            sfhist = hist.Hist(*hists[self.hist_producers[0]][self.variables[0]][0, ..., 0].axes, data=scale_factors)
+            sfhist.name = f"sf_{self.trigger}_{self.variables[0]}"
+            sfhist.label = "out"
+
+            nominal_scale_factors = correctionlib.convert.from_histogram(sfhist)
+            nominal_scale_factors.description = f"{self.trigger} scale factors, binned in {self.variables[0]}"
+
+            # set overflow bins behavior (default is to raise an error when out of bounds)
+            nominal_scale_factors.data.flow = "clamp"
+
+            # add uncertainties
+            sfhist_up = hist.Hist(
+                *hists[self.hist_producers[0]][self.variables[0]][0, ..., 0].axes, data=scale_factors + uncertainties
+            )
+            sfhist_up.name = f"sf_{self.trigger}_{self.variables[0]}_up"
+            sfhist_up.label = "out"
+
+            upwards_scale_factors = correctionlib.convert.from_histogram(sfhist_up)
+            upwards_scale_factors.description = f"{self.trigger} scale factors, binned in {self.variables[0]}, upwards variation" # noqa
+
+            # set overflow bins behavior (default is to raise an error when out of bounds)
+            upwards_scale_factors.data.flow = "clamp"
+
+            sfhist_down = hist.Hist(
+                *hists[self.hist_producers[0]][self.variables[0]][0, ..., 0].axes, data=scale_factors - uncertainties
+            )
+            sfhist_down.name = f"sf_{self.trigger}_{self.variables[0]}_down"
+            sfhist_down.label = "out"
+
+            downwards_scale_factors = correctionlib.convert.from_histogram(sfhist_down)
+            downwards_scale_factors.description = f"{self.trigger} scale factors, binned in {self.variables[0]}, downwards variation" # noqa
+
+            # set overflow bins behavior (default is to raise an error when out of bounds)
+            downwards_scale_factors.data.flow = "clamp"
+
+            # create correction set and store it
+            cset = correctionlib.schemav2.CorrectionSet(
+                schema_version=2,
+                description=f"{self.trigger} scale factors",
+                corrections=[
+                    nominal_scale_factors,
+                    upwards_scale_factors,
+                    downwards_scale_factors,
+                ],
+            )
+            cset_json = cset.json(exclude_unset=True)
+
+            # plot 1D or 2D scalefactors
+            if len(sfhist.axes.size) <= 2:
+                # use CMS plotting style
+                plt.style.use(mplhep.style.CMS)
+
+                if len(sfhist.axes.size) == 2:
+                    fig, ax = plt.subplots()
+                else:
+                    fig, axs = plt.subplots(2, 1, gridspec_kw=dict(height_ratios=[7, 5], hspace=0), sharex=True)
+                    (ax, rax) = axs
+                    # fig, ax = plt.subplots()
+
+                if len(sfhist.axes.size) == 2:
+                    plot2d = True
+                    if plot2d:
+                        sfhist.plot2d(ax=ax, cmap="viridis")
+                        # Annotate each bin with its relative uncertainty
+                        for i in range(len(sfhist.axes[0].centers)):
+                            for j in range(len(sfhist.axes[1].centers)):
+                                unc = uncertainties[i, j]  # rel_unc[i, j]
+                                value = scale_factors[i, j]
+                                if unc > 0:
+                                    if sfhist.axes[0].centers[i] < 400 and sfhist.axes[1].centers[j] < 400:
+                                        ax.text(sfhist.axes[0].centers[i], sfhist.axes[1].centers[j],
+                                                f'{value:.2f}\n$\\pm${unc:.2f}',
+                                                ha='center', va='center', color='white', fontsize=12)
+                        ax.plot([1, 400], [1, 400], linestyle="dashed", color="gray")
+                        # ax.set_xscale("log")
+                        # ax.set_yscale("log")
+
+                        # ax.set_xlim(15, 400)
+                        # ax.set_ylim(15, 400)
+                        # ax.set_xticks([25, 50, 100, 150, 250, 400])
+                        # ax.set_yticks([25, 50, 100, 150, 250, 400])
+
+                        # ax.set_ylim(15, 60)
+                        # ax.set_xlim(15, 200)
+                        # ax.set_yticks([20, 30, 40, 50, 60])
+                        # ax.set_xticks([25, 50, 100, 150])
+
+                        ax.get_xaxis().set_major_formatter(mpl.ticker.ScalarFormatter())
+                        ax.get_yaxis().set_major_formatter(mpl.ticker.ScalarFormatter())
+                        ax.set_xlabel(r"Leading lepton $p_T$ / GeV")
+                        ax.set_ylabel(r"Subleading lepton $p_T$ / GeV")
+                    else:
+                        fig, axs = plt.subplots(4, 1, gridspec_kw=dict(hspace=0), sharex=True)
+                        for key in [4, 3, 2, 1]:
+                            axs[key - 1].errorbar(
+                                x=sfhist[:, key].axes.centers[0], y=sfhist[:, key].values(),
+                                yerr=uncertainties[:, key],
+                                fmt="o",
+                                label=f"{sfhist[0,:].axes.edges[0][key]}<lep2 $p_T$<{sfhist[0,:].axes.edges[0][key+1]}")
+
+                            axs[key - 1].set_ylim(0.70, 1.13)
+                            axs[key - 1].legend(loc="lower right")
+                            axs[key - 1].plot([15, 400], [1, 1], linestyle="dashed", color="gray")
+
+                        axs[0].set_ylabel("Data/MC")
+                        axs[-1].set_xlabel(r"Leading lepton $p_T$ / GeV")
+                        ax = axs[0]
+                else:
+                    # trig_label = r"$e\mu$ trigger" if self.trigger == "mixed" else f"{self.trigger} trigger"
+                    if "Data" in self.config_inst.get_process(self.processes[0]).label:
+                        from hbw.util import debugger
+                        debugger()
+                        proc_label0 = r"$\varepsilon_{\text{Data}}$"
+                        proc_label1 = r"$\varepsilon_{\text{MC},t\bar{t}+DY}$"
+                    else:
+                        proc_label1 = r"$\varepsilon_{\text{Data}}$"
+                        proc_label0 = r"$\varepsilon_{\text{MC},t\bar{t}}$"
+                    # proc_label0 = self.config_inst.get_process(self.processes[0]).label
+                    # proc_label1 = self.config_inst.get_process(self.processes[1]).label
+                    # proc_label0 = proc_label0[:-4] if "DL" in proc_label0 else proc_label0
+                    # proc_label1 = proc_label1[:-4] if "DL" in proc_label1 else proc_label1
+                    ax.errorbar(
+                        x=sfhist.axes[0].centers, y=efficiencies[0], yerr=efficiency_unc[0],
+                        fmt="o", label=f"{proc_label0}")
+                    ax.errorbar(
+                        x=sfhist.axes[0].centers, y=efficiencies[1], yerr=efficiency_unc[1],
+                        fmt="o", label=f"{proc_label1}")
+                    # rax.errorbar(x=sfhist.axes[0].centers, y=scale_factors, yerr=unc_with_sf_env, fmt="o",
+                    #              color="tab:orange")
+                    # rax.errorbar(x=sfhist.axes[0].centers, y=sfhist.values(), xerr=4.5, fmt=",", color="tab:grey")
+                    # comb_unc = np.sqrt(uncertainties**2 + sf_env_unc**2 + (1-alpha_factors)**2)
+                    # rax.errorbar(x=sfhist.axes[0].centers, y=sfhist.values(), yerr=comb_unc, fmt=",",
+                    #              label="total uncertainty", elinewidth=4)
+                    rax.errorbar(x=sfhist.axes[0].centers, y=sfhist.values(), yerr=uncertainties, fmt="o")
+                    # rax.errorbar(x=sfhist.axes[0].centers-2, y=sfhist.values(), yerr=uncertainties, fmt=",",
+                    #              label="statistical", elinewidth=4)
+                    # rax.errorbar(x=sfhist.axes[0].centers, y=sfhist.values(), yerr=np.sqrt((1-alpha_factors)**2),
+                    #              fmt=",", label=r"$\alpha$", elinewidth=4)
+                    # rax.errorbar(x=sfhist.axes[0].centers+2, y=sfhist.values(), yerr=sf_env_unc, fmt=",",
+                    #              label="npv envelope", elinewidth=4)
+                    # #   # rax.errorbar(x=sfhist.axes[0].centers, y=sf_envelope["up"], yerr=0.0, fmt="o", color="lightblue",  # noqa
+                    # #   #              label=f"npv>{self.half_point}", markersize=5)
+                    # #   # rax.errorbar(x=sfhist.axes[0].centers, y=sf_envelope["down"], yerr=0.0, fmt="o", color="steelblue",  # noqa
+                    # #   #              label=f"npv<{self.half_point}", markersize=5)
+                    rax.axhline(y=1.0, linestyle="dashed", color="gray")
+                    rax_kwargs = {
+                        "ylim": (0.92, 1.08),
+                        "xlim": (0, 200),
+                        "ylabel": "Scale factors",
+                        "xlabel": r"Leading lepton $p_T$ / GeV",  # f"{sfhist.axes[0].label}",  #
+                        "yscale": "linear",
+                    }
+                    rax.legend(loc="upper left", handletextpad=-0.3, ncol=2)
+                    rax.set(**rax_kwargs)
+                    ax.set_ylabel("Efficiency")
+                    ax.set_ylim(0, 1.5)
+                    # ax.set_xlim(0, 200)
+                    # ax.set_xlabel(r"Leading lepton $p_T$ / GeV")
+
+                    label = self.config_inst.get_category(self.categories[0]).label
+                    ax.annotate(label, xy=(0.05, 0.85), xycoords="axes fraction",
+                                fontsize=20)
+
+                ax.legend(fontsize=26)
+                cms_label_kwargs = {
+                    "ax": ax,
+                    "llabel": "Private work (CMS data/simulation)",
+                    "fontsize": 22,
+                    "data": False,
+                    "exp": "",
+                    "com": self.config_inst.campaign.ecm,
+                    "lumi": round(0.001 * self.config_inst.x.luminosity.get("nominal"), 2)
+                }
+                mplhep.cms.label(**cms_label_kwargs)
+                fig.tight_layout()
+
+        # optimising the binning for 2d histograms results in a non uniform binning, a different workflow is needed
+        elif len(self.variables[0].split("-")[:-1]) == 2:
+
+            # optimise second axis, return accondingly optimised edges of first axis
+            histslices, edges2 = optimise_binning2d(
+                calculator=self,
+                hists=hists,
+                target_uncertainty1=0.02,
+                target_uncertainty2=0.04
+            )
+
+            sliced_scale_factors = {}
+            sliced_uncertainties = {}
+            sliced_efficiencies = {}
+            sliced_efficiency_unc = {}
+            rel_unc = {}
+
+            x_edges = hists[self.hist_producers[0]][self.variables[0]].axes[1].edges
+
+            for key, sliced_hist in histslices.items():
+                scale_factors, uncertainties, efficiencies, efficiency_unc = self.calc_sf_and_unc(sliced_hist, envelope=True)  # noqa
+                scale_factors[uncertainties == 0.0] = None
+                sliced_scale_factors[key] = scale_factors
+                sliced_uncertainties[key] = uncertainties
+                sliced_efficiencies[key] = efficiencies
+                sliced_efficiency_unc[key] = efficiency_unc
+                rel_unc[key] = uncertainties / scale_factors
+
+            plt.style.use(mplhep.style.CMS)
+
+            plot_unrolled = False
+            if plot_unrolled:
+                fig, axs = plt.subplots(len(x_edges) - 1, 1, gridspec_kw=dict(hspace=0), sharex=True)
+
+                for key, h in histslices.items():
+                    axs[key].errorbar(
+                        x=h[self.hist_producers[0]][self.variables[0]].axes[1].centers, y=sliced_scale_factors[key],
+                        yerr=sliced_uncertainties[key],
+                        fmt="o", label=f"{x_edges[key]}<lep2pt<{x_edges[key+1]}")
+
+                    axs[key].set_ylim(0.87, 1.13)
+                    axs[key].legend()
+
+                axs[int(len(x_edges) / 2)].set_ylabel("Data/MC")
+                ax = axs[0]
+
+            else:
+
+                sfs = np.ones(shape=(400, 400))
+                sfs[0, :] = None
+                sfs[:, 0] = None
+                for i in range(1, 400):
+                    for j in range(1, 400):
+                        idx = np.searchsorted(x_edges, i) - 1
+                        idy = np.searchsorted(edges2[idx], j) - 1
+                        if j > x_edges[idx + 1]:
+                            sfs[i, j] = None
+                        else:
+                            sfs[i, j] = sliced_scale_factors[idx][idy]
+
+                sfhist = hist.Hist(*old_axes, data=sfs)
+                sfhist.name = f"sf_{self.trigger}_{self.variables[0]}"
+                sfhist.label = "out"
+                plt.style.use(mplhep.style.CMS)
+                fig, ax = plt.subplots()
+                sfhist.plot2d(ax=ax,)
+                ax.plot([0, 150], [0, 150], linestyle="dashed", color="gray")
+                ax.set_xlim(0, 150)
+                ax.set_xticks([50, 100, 150])
+                ax.set_ylim(0, 150)
+                ax.set_yticks([50, 100, 150])
+                ax.set_xlabel(r"Leading lepton $p_T$ / GeV")
+                ax.set_ylabel(r"Subleading lepton $p_T$ / GeV")
+
+            cms_label_kwargs = {
+                "ax": ax,
+                "llabel": "Private work (CMS data/simulation)",
+                "fontsize": 22,
+                "data": False,
+                "exp": "",
+                "com": self.config_inst.campaign.ecm,
+                "lumi": round(0.001 * self.config_inst.x.luminosity.get("nominal"), 2)
+            }
+            mplhep.cms.label(**cms_label_kwargs)
+            fig.tight_layout()
+        # alternative plt nonuniformimage
+        #  save outputs
+        outputs["trigger_scale_factors"].dump(
+            cset_json,
+            formatter="json",
+        )
+        outputs["trigger_sf_plot"].dump(
+            fig,
+            formatter="mpl",
+        )

--- a/trigger/trigger_util.py
+++ b/trigger/trigger_util.py
@@ -1,0 +1,308 @@
+# coding: utf-8
+
+"""
+Some utils for trigger studies and efficiency calculations
+"""
+
+from __future__ import annotations
+
+import law
+
+from columnflow.util import maybe_import
+
+from hbw.config.hist_hooks import rebin_hist
+
+logger = law.logger.get_logger(__name__)
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+scipy = maybe_import("scipy")
+mpl = maybe_import("matplotlib")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+ak = maybe_import("awkward")
+
+
+def safe_div(num, den, default=1.0):
+    """
+    Safely divide two arrays, setting the result to:
+    - num / den where num >= 0 and den > 0
+    - 0 where num == 0 and den == 0
+    - 1 where num >= 0 and den == 0
+    at the moment not used
+    """
+    return np.where(
+        (num == 0) & (den == 0),
+        default,
+        np.where(
+            (num >= 0) & (den > 0),
+            num / den,
+            1.0
+        )
+    )
+
+
+def binom_int(num, den, confint=0.68):
+    """
+    calculates clopper-pearson error
+    """
+    from scipy.stats import beta
+    quant = (1 - confint) / 2.
+    low = beta.ppf(quant, num, den - num + 1)
+    high = beta.ppf(1 - quant, num + 1, den - num)
+    return (np.nan_to_num(low), np.where(np.isnan(high), 1, high))
+
+
+def calc_efficiency_errors(num, den):
+    """
+    Calculate the error on an efficiency given the numerator and denominator histograms.
+    """
+
+    # Use the variance to scale the numerator and denominator to remove an average weight,
+    # this reduces the errors for rare processes to more realistic values
+    num_scale = np.nan_to_num(num.values() / num.variances(), nan=1)
+    den_scale = num_scale  # np.nan_to_num(den.values() / den.variances(), nan=1)
+
+    efficiency = np.nan_to_num((num.values() * num_scale) / (den.values() * den_scale), nan=0, posinf=1, neginf=0)
+
+    if np.any(efficiency > 1):
+        logger.warning(
+            "Some efficiencies for are greater than 1",
+        )
+    elif np.any(efficiency < 0):
+        logger.warning(
+            "Some efficiencies for are less than 0",
+        )
+
+    band_low, band_high = binom_int(num.values() * num_scale, den.values() * den_scale)
+
+    error_low = np.asarray(efficiency - band_low)
+    error_high = np.asarray(band_high - efficiency)
+
+    # remove negative errors
+    if np.any(error_low < 0):
+        logger.warning("Some lower uncertainties are negative, setting them to zero")
+        error_low[error_low < 0] = 0
+    if np.any(error_high < 0):
+        logger.warning("Some upper uncertainties are negative, setting them to zero")
+        error_high[error_high < 0] = 0
+
+    # remove large errors if the efficiency is zero
+    error_low[efficiency == 0] = 0
+    error_high[efficiency == 0] = 0
+
+    # stacking errors
+    errors = np.concatenate(
+        (np.expand_dims(error_low, axis=1), np.expand_dims(error_high, axis=1)),
+        axis=1,
+    )
+    # this works for 1D histograms but needs to be undone for 2d histograms, no idea why
+    errors = errors.T
+
+    return errors
+
+
+def calc_sf_uncertainty(efficiencies: dict, errors: dict, alpha: np.ndarray):
+    """
+    Calculate the error on the scale factors using a gaussian error propagation.
+    """
+    # symmetrize errors
+    sym_errors = {}
+    for key, value in errors.items():
+        if value.ndim == 2 and value.shape[0] == 2:
+            sym_errors[key] = np.maximum(value[0], value[1])
+        else:
+            # here the transponse is undone again
+            sym_errors[key] = np.maximum(value.T[..., 0, :], value.T[..., 1, :])
+
+    # combine errors
+    uncertainty = np.sqrt(
+        (sym_errors[0] / efficiencies[1]) ** 2 + (efficiencies[0] * sym_errors[1] / efficiencies[1] ** 2) ** 2 # + (1 - alpha) ** 2  # noqa
+    )
+
+    return np.nan_to_num(uncertainty, nan=0, posinf=1, neginf=0)
+
+
+def calculate_efficiencies(
+        h: hist.Hist,
+        trigger: str,
+) -> dict:
+    """
+    Calculates the efficiencies for the different triggers.
+    """
+    efficiencies = {}
+    efficiency_unc = {}
+    # loop over processes
+    for proc in range(h.axes[0].size):
+
+        efficiency = np.nan_to_num(h[proc, ..., hist.loc(trigger)].values() / h[proc, ..., 0].values(),
+                                   nan=0, posinf=1, neginf=0
+                                   )
+
+        if np.any(efficiency > 1):
+            logger.warning(
+                "Some efficiencies for are greater than 1, errorbars are capped at zero",
+            )
+        elif np.any(efficiency < 0):
+            logger.warning(
+                "Some efficiencies for are less than 0, errorbars are capped at zero",
+            )
+
+        efficiencies[proc] = efficiency
+
+        efficiency_unc[proc] = calc_efficiency_errors(h[proc, ..., hist.loc(trigger)], h[proc, ..., 0])
+
+    return efficiencies, efficiency_unc
+
+
+def optimise_binning1d(
+    calculator,
+    hists: dict[str, hist.Hist],
+    target_uncertainty: float | None = 0.05,
+    premade_edges: np.ndarray | None = None,
+    variable: str | None = None,
+) -> dict[str, hist.Hist]:
+    """
+    Optimise the binning of a set of histograms to achieve a target uncertainty
+    """
+
+    variables = calculator.variables[0]
+    if variable is None:
+        variable = variables.split("-")[0]
+
+    efficiencies = {
+        calculator.hist_producers[0]: {},
+        calculator.hist_producers[1]: {},
+    }
+    efficiency_unc = {
+        calculator.hist_producers[0]: {},
+        calculator.hist_producers[1]: {},
+    }
+
+    bins_optimised = False
+    # get edges
+    if premade_edges is not None:
+        edges = premade_edges
+        # apply edges
+        for hist_producer in calculator.hist_producers:
+            hist = hists[hist_producer][variables]
+            hist = rebin_hist(hist, variable, edges)
+            hists[hist_producer][variables] = hist
+        bins_optimised = True
+    else:
+        edges = hists[calculator.hist_producers[0]][variables].axes[variable].edges
+
+    while not bins_optimised:
+        # apply edges
+        for hist_producer in calculator.hist_producers:
+            hist = hists[hist_producer][variables]
+            hist = rebin_hist(hist, variable, edges)
+            hists[hist_producer][variables] = hist
+
+        # calculate scale factors and uncertainties
+        for hist_producer in calculator.hist_producers:
+            # calculate efficiencies. process, shift, variable, bin
+            efficiencies[hist_producer], efficiency_unc[hist_producer] = calculate_efficiencies(
+                hists[hist_producer][calculator.variables[0]][:, ..., :], calculator.trigger
+            )
+
+        # calculate scale factors, second weight producer is used
+        scale_factors = np.nan_to_num(
+            efficiencies[calculator.hist_producers[1]][0] / efficiencies[calculator.hist_producers[1]][1],
+            nan=1,
+            posinf=1,
+            neginf=1,
+        )
+        # calculate alpha factors
+        alpha_factors = np.nan_to_num(
+            efficiencies[calculator.hist_producers[0]][1] / efficiencies[calculator.hist_producers[1]][1],
+            nan=1,
+            posinf=1,
+            neginf=1,
+        )
+
+        # only use the efficiencies and uncertainties of the second weight producer
+        efficiencies = efficiencies[calculator.hist_producers[1]]
+        efficiency_unc = efficiency_unc[calculator.hist_producers[1]]
+        # calculate scale factor uncertainties, only statistical uncertainties are considered right now
+        uncertainties = calc_sf_uncertainty(
+            efficiencies, efficiency_unc, alpha_factors
+        )
+
+        # check for uncertainties larger than 5%
+        rel_unc = uncertainties / scale_factors
+        low_stat_bins = np.where(rel_unc > target_uncertainty)[0]
+        # maybe np.where((rel_unc > target_uncertainty) or rel_unc == 0.0)[0] to merge empty bins?
+
+        # merge bins
+        if len(low_stat_bins) > 0 and edges[low_stat_bins[0] + 1] != 400.0:
+            edges = np.delete(edges, low_stat_bins[0] + 1)
+        else:
+            bins_optimised = True
+
+        # merge empty bins
+        empty_bins = np.where(rel_unc == 0.0)[0]
+        if len(empty_bins) > 1 and [edges[empty_bins[0]], edges[empty_bins[1]]] != [0.0, 400.0]:
+            edges = np.delete(edges, empty_bins[1])
+
+    logger.info(f"new edges: {edges}")
+
+    return hists, edges
+
+
+def optimise_binning2d(
+    calculator,
+    hists: dict[str, hist.Hist],
+    target_uncertainty1: float | None = 0.01,
+    target_uncertainty2: float | None = 0.05,
+    premade_edges: np.ndarray | None = None,
+) -> dict[str, np.ndarray]:
+    """
+    Optimise the binning of a set of histograms to achieve a target uncertainty in 2 dimensions
+    target_uncertainty1 is for the first optimization and should be small enough to yield usable uncertainties
+    when binning in the second dimension
+    """
+
+    variables = calculator.variables[0]
+    variable = variables.split("-")
+
+    # optimise first axis
+    hists1 = {
+        calculator.hist_producers[0]: {},
+        calculator.hist_producers[1]: {},
+    }
+    for hist_producer in calculator.hist_producers:
+        hist1 = hists[hist_producer][variables][{f"{variable[1]}": sum}]
+        hists1[hist_producer][variables] = hist1
+
+    logger.info("Optimising first axis")
+
+    hists1, edges1 = optimise_binning1d(
+        calculator, hists1, target_uncertainty1, variable=variable[0]
+    )
+
+    # apply edges
+    for hist_producer in calculator.hist_producers:
+        hist = hists[hist_producer][variables]
+        hist = rebin_hist(hist, variable[0], edges1)
+        hists[hist_producer][variables] = hist
+
+    logger.info("Optimising second axis")
+
+    # optimise first axis
+    edges2 = {}
+    histslices = {}
+    for subslice in range(len(hists[hist_producer][variables].axes[1].centers)):
+        hists2 = {
+            calculator.hist_producers[0]: {},
+            calculator.hist_producers[1]: {},
+        }
+        for hist_producer in calculator.hist_producers:
+            hist2 = hists[hist_producer][variables][:, subslice, :, :]
+            hists2[hist_producer][variables] = hist2
+
+        histslices[subslice], edges2[subslice] = optimise_binning1d(
+            calculator, hists2, target_uncertainty2, variable=variable[1]
+        )
+
+    return histslices, edges2


### PR DESCRIPTION
Adds check for unprescaled L1 seeds in the selection as well as the functionality to calculate trigger efficiencies and scale factors (although a different columnflow branch is needed for the efficiencies).

Also adds a baseline for the 2022 single lepton channel.

This time the impact on the rest of the analysis should be minimal.